### PR TITLE
localStorage tools were added

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
     "./tools/common": "./lib/tools/common.js",
     "./tools/screenshot": "./lib/tools/screenshot.js",
     "./tools/snapshot": "./lib/tools/snapshot.js",
+    "./tools/localStorage": "./lib/tools/localStorage.js",
     "./package.json": "./package.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "commander": "^13.1.0",
     "playwright": "1.52.0-alpha-2025-03-21",
+    "zod": "^3.22.4",
     "zod-to-json-schema": "^3.24.4"
   },
   "devDependencies": {
@@ -40,10 +42,11 @@
     "@eslint/js": "^9.19.0",
     "@playwright/test": "1.52.0-alpha-2025-03-21",
     "@stylistic/eslint-plugin": "^3.0.1",
+    "@types/commander": "^2.12.2",
+    "@types/node": "^22.13.10",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",
     "@typescript-eslint/utils": "^8.26.1",
-    "@types/node": "^22.13.10",
     "eslint": "^9.19.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-notice": "^1.0.0",

--- a/src/tools/localStorage.ts
+++ b/src/tools/localStorage.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { Tool } from './tool';
+
+const getItemSchema = z.object({
+  key: z.string().describe('The key to retrieve from localStorage'),
+});
+
+export const getItem: Tool = {
+  schema: {
+    name: 'browser_localStorage_get',
+    description: 'Get an item from localStorage by key',
+    inputSchema: zodToJsonSchema(getItemSchema),
+  },
+
+  handle: async (context, params) => {
+    const validatedParams = getItemSchema.parse(params);
+    const page = await context.ensurePage();
+    const value = await page.evaluate((key: string) => window.localStorage.getItem(key), validatedParams.key);
+    return {
+      content: [{
+        type: 'text',
+        text: `Retrieved "${validatedParams.key}" from localStorage: ${value === null ? 'null' : `"${value}"`}`,
+      }],
+    };
+  },
+};
+
+const setItemSchema = z.object({
+  key: z.string().describe('The key to set in localStorage'),
+  value: z.string().describe('The value to set for the key'),
+});
+
+export const setItem: Tool = {
+  schema: {
+    name: 'browser_localStorage_set',
+    description: 'Set an item in localStorage',
+    inputSchema: zodToJsonSchema(setItemSchema),
+  },
+
+  handle: async (context, params) => {
+    const validatedParams = setItemSchema.parse(params);
+    const page = await context.ensurePage();
+    await page.evaluate(({ key, value }: { key: string; value: string }) => window.localStorage.setItem(key, value), validatedParams);
+    return {
+      content: [{
+        type: 'text',
+        text: `Set localStorage key "${validatedParams.key}" to "${validatedParams.value}"`,
+      }],
+    };
+  },
+};
+
+const removeItemSchema = z.object({
+  key: z.string().describe('The key to remove from localStorage'),
+});
+
+export const removeItem: Tool = {
+  schema: {
+    name: 'browser_localStorage_remove',
+    description: 'Remove an item from localStorage by key',
+    inputSchema: zodToJsonSchema(removeItemSchema),
+  },
+
+  handle: async (context, params) => {
+    const validatedParams = removeItemSchema.parse(params);
+    const page = await context.ensurePage();
+    await page.evaluate((key: string) => window.localStorage.removeItem(key), validatedParams.key);
+    return {
+      content: [{
+        type: 'text',
+        text: `Removed "${validatedParams.key}" from localStorage`,
+      }],
+    };
+  },
+};
+
+const clearSchema = z.object({});
+
+export const clear: Tool = {
+  schema: {
+    name: 'browser_localStorage_clear',
+    description: 'Clear all items from localStorage',
+    inputSchema: zodToJsonSchema(clearSchema),
+  },
+
+  handle: async (context) => {
+    const page = await context.ensurePage();
+    await page.evaluate(() => window.localStorage.clear());
+    return {
+      content: [{
+        type: 'text',
+        text: 'Cleared all items from localStorage',
+      }],
+    };
+  },
+};
+
+const getAllSchema = z.object({});
+
+export const getAll: Tool = {
+  schema: {
+    name: 'browser_localStorage_getAll',
+    description: 'Get all items from localStorage',
+    inputSchema: zodToJsonSchema(getAllSchema),
+  },
+
+  handle: async (context) => {
+    const page = await context.ensurePage();
+    const items = await page.evaluate(() => {
+      const all: Record<string, string> = {};
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key) {
+          all[key] = window.localStorage.getItem(key) || '';
+        }
+      }
+      return all;
+    });
+    
+    return {
+      content: [{
+        type: 'text',
+        text: `localStorage contents:\n${JSON.stringify(items, null, 2)}`,
+      }],
+    };
+  },
+}; 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -60,6 +60,21 @@ test('test tool list', async ({ server }) => {
         expect.objectContaining({
           name: 'browser_close',
         }),
+        expect.objectContaining({
+          name: 'browser_localStorage_get',
+        }),
+        expect.objectContaining({
+          name: 'browser_localStorage_set',
+        }),
+        expect.objectContaining({
+          name: 'browser_localStorage_remove',
+        }),
+        expect.objectContaining({
+          name: 'browser_localStorage_clear',
+        }),
+        expect.objectContaining({
+          name: 'browser_localStorage_getAll',
+        }),
       ],
     }),
   }));
@@ -157,6 +172,132 @@ test('test browser_click', async ({ server }) => {
   - button \"Submit\" [ref=s2e4]
 \`\`\`
 `,
+      }],
+    },
+  }));
+});
+
+test('test localStorage tools', async ({ server }) => {
+  await server.send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: {
+      name: 'browser_navigate',
+      arguments: {
+        url: 'data:text/html,<html><title>Title</title><body>Test localStorage</body></html>',
+      },
+    },
+  });
+
+  // Test setItem
+  const setResponse = await server.send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'browser_localStorage_set',
+      arguments: {
+        key: 'testKey',
+        value: 'testValue',
+      },
+    },
+  });
+
+  expect(setResponse).toEqual(expect.objectContaining({
+    id: 2,
+    result: {
+      content: [{
+        type: 'text',
+        text: 'Set localStorage key "testKey" to "testValue"',
+      }],
+    },
+  }));
+
+  // Test getItem
+  const getResponse = await server.send({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: 'browser_localStorage_get',
+      arguments: {
+        key: 'testKey',
+      },
+    },
+  });
+
+  expect(getResponse).toEqual(expect.objectContaining({
+    id: 3,
+    result: {
+      content: [{
+        type: 'text',
+        text: 'Retrieved "testKey" from localStorage: "testValue"',
+      }],
+    },
+  }));
+
+  // Test getAll
+  const getAllResponse = await server.send({
+    jsonrpc: '2.0',
+    id: 4,
+    method: 'tools/call',
+    params: {
+      name: 'browser_localStorage_getAll',
+      arguments: {},
+    },
+  });
+
+  expect(getAllResponse).toEqual(expect.objectContaining({
+    id: 4,
+    result: {
+      content: [{
+        type: 'text',
+        text: 'localStorage contents:\n{\n  "testKey": "testValue"\n}',
+      }],
+    },
+  }));
+
+  // Test removeItem
+  const removeResponse = await server.send({
+    jsonrpc: '2.0',
+    id: 5,
+    method: 'tools/call',
+    params: {
+      name: 'browser_localStorage_remove',
+      arguments: {
+        key: 'testKey',
+      },
+    },
+  });
+
+  expect(removeResponse).toEqual(expect.objectContaining({
+    id: 5,
+    result: {
+      content: [{
+        type: 'text',
+        text: 'Removed "testKey" from localStorage',
+      }],
+    },
+  }));
+
+  // Test clear
+  const clearResponse = await server.send({
+    jsonrpc: '2.0',
+    id: 6,
+    method: 'tools/call',
+    params: {
+      name: 'browser_localStorage_clear',
+      arguments: {},
+    },
+  });
+
+  expect(clearResponse).toEqual(expect.objectContaining({
+    id: 6,
+    result: {
+      content: [{
+        type: 'text',
+        text: 'Cleared all items from localStorage',
       }],
     },
   }));


### PR DESCRIPTION
## Overview
This PR adds comprehensive localStorage handling capabilities to the Playwright MCP repository, enabling automation scripts to interact with browser localStorage. The implementation includes a complete set of tools for managing localStorage data with proper TypeScript typing, validation, and test coverage.

## Features
- **New Tools Added:**
  - `browser_localStorage_get`: Retrieve items from localStorage by key
  - `browser_localStorage_set`: Store items in localStorage
  - `browser_localStorage_remove`: Remove specific items from localStorage
  - `browser_localStorage_clear`: Clear all items from localStorage
  - `browser_localStorage_getAll`: Get all items currently in localStorage

## Implementation Details
### New Files
- `src/tools/localStorage.ts`: Core implementation of localStorage tools
  - Uses Zod for schema validation and type safety
  - Implements proper error handling
  - Follows existing codebase patterns and conventions

### Modified Files
- `src/program.ts`: 
  - Added localStorage tools to `commonTools` array
  - Tools available in both snapshot and screenshot modes
- `package.json`:
  - Added `zod` dependency
  - Added `@types/commander` dev dependency
  - Added localStorage tools to exports
- `tests/basic.spec.ts`:
  - Added comprehensive test suite for localStorage operations
  - Covers all new tool functionalities

## Example Usage
```typescript
// Set an item
await tools.call('browser_localStorage_set', {
  key: 'user_preferences',
  value: JSON.stringify({ theme: 'dark' })
});

// Get an item
const response = await tools.call('browser_localStorage_get', {
  key: 'user_preferences'
});

// Get all items
const allItems = await tools.call('browser_localStorage_getAll', {});
```

## Dependencies
- Added `zod`: ^3.22.4
  - Used for runtime validation and schema definition
  - Provides TypeScript type inference
  - Generates JSON Schema for API documentation