### PR TITLE
chore: Add TypeScript declaration files to the published package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "strict": true,
     "module": "CommonJS",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "declaration": true
   },
   "include": [
     "src",


### PR DESCRIPTION

Currently, the npm package doesn't include TypeScript definition files:
https://www.npmjs.com/package/@playwright/mcp/v/0.0.3?activeTab=code

This causes TypeScript projects to treat imports as untyped:

```ts
import { createServer } from "@playwright/mcp"; // ts(2307) error
```

This PR adds `declaration: true` to the tsconfig.json to generate .d.ts files during the build process, ensuring TypeScript users get proper type information and editor features like autocompletion and type checking.