### PR TITLE
browser://console should be single resource

### DIFF
--- a/src/resources/console.ts
+++ b/src/resources/console.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Resource, ResourceResult } from './resource';
+import type { Resource } from './resource';
 
 export const console: Resource = {
   schema: {
@@ -24,14 +24,12 @@ export const console: Resource = {
   },
 
   read: async (context, uri) => {
-    const result: ResourceResult[] = [];
-    for (const message of await context.ensureConsole()) {
-      result.push({
-        uri,
-        mimeType: 'text/plain',
-        text: `[${message.type().toUpperCase()}] ${message.text()}`,
-      });
-    }
-    return result;
+    const messages = await context.ensureConsole();
+    const log = messages.map(message => `[${message.type().toUpperCase()}] ${message.text()}`).join('\n');
+    return [{
+      uri,
+      mimeType: 'text/plain',
+      text: log
+    }];
   },
 };

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -331,3 +331,35 @@ test.describe('test browser_select_option', () => {
     }));
   });
 });
+
+test('browser://console', async ({ server }) => {
+  await server.send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'browser_navigate',
+      arguments: {
+        url: 'data:text/html,<html><script>console.log("Hello, world!");console.error("Error"); </script></html>',
+      },
+    },
+  });
+
+  const response = await server.send({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'resources/read',
+    params: {
+      uri: 'browser://console',
+    },
+  });
+  expect(response).toEqual(expect.objectContaining({
+    result: expect.objectContaining({
+      contents: [{
+        uri: 'browser://console',
+        mimeType: 'text/plain',
+        text: '[LOG] Hello, world!\n[ERROR] Error',
+      }],
+    }),
+  }));
+});


### PR DESCRIPTION
Returning one resource per log line is flooding the Claude UI:

<img width="1061" alt="Screenshot 2025-03-19 at 16 01 45" src="https://github.com/user-attachments/assets/1779374e-6b9d-44d7-b916-c521933e1085" />

Returning one big resource with all lines feels better.

original PR: https://github.com/microsoft/playwright/pull/35276