### PR TITLE
Update binary name to mcp-server-playwright (fixes #33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "typescript": "^5.8.2"
   },
   "bin": {
-    "mcp": "cli.js"
+    "mcp-server-playwright": "cli.js"
   }
 }


### PR DESCRIPTION
This PR updates the binary name in `package.json` from `mcp` to `mcp-server-playwright` as requested in issue #33. The change makes the binary name more specific, avoiding conflicts with other MCP servers and improving usability for global installations.

Fixes #33