### PR TITLE
fix: stitch all frames into one snapshot

### DIFF
--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -133,5 +133,13 @@ export const selectOption: Tool = {
 };
 
 function refLocator(page: playwright.Page, ref: string): playwright.Locator {
-  return page.locator(`aria-ref=${ref}`);
+  let frame = page.frames()[0];
+  const match = ref.match(/^f(\d+)(.*)/);
+  if (match) {
+    const frameIndex = parseInt(match[1], 10);
+    frame = page.frames()[frameIndex];
+    ref = match[2];
+  }
+
+  return frame.locator(`aria-ref=${ref}`);
 }

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -363,3 +363,37 @@ test('browser://console', async ({ server }) => {
     }),
   }));
 });
+
+test('stitched aria frames', async ({ server }) => {
+  const response = await server.send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'browser_navigate',
+      arguments: {
+        url: 'data:text/html,<h1>Hello</h1><iframe src="data:text/html,<h1>World</h1>"></iframe>',
+      },
+    },
+  });
+
+  expect(response).toEqual(expect.objectContaining({
+    id: 2,
+    result: {
+      content: [{
+        type: 'text',
+        text: `
+- Page URL: data:text/html,<h1>Hello</h1><iframe src="data:text/html,<h1>World</h1>"></iframe>
+- Page Title: 
+- Page Snapshot
+\`\`\`yaml
+- document [ref=s1e2]:
+  - heading \"Hello\" [level=1] [ref=s1e4]
+- document [ref=f1s1e2]:
+  - heading \"World\" [level=1] [ref=f1s1e4]
+\`\`\`
+`,
+      }],
+    },
+  }));
+});


### PR DESCRIPTION
Resolves https://github.com/microsoft/playwright-mcp/issues/35 by stitching together aria snapshots for all frames into one. We can't build a proper tree because the ARIA snapshot doesn't contain iframe elements, but concatenating should work just fine for now.

Prompt I used for testing:
```
what jobs are on https://careers-changegrowlive.icims.com/jobs/
```