### PR TITLE
chore: stitch together iframes into one tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.6.1",
         "commander": "^13.1.0",
         "playwright": "^1.52.0-alpha-1743163434000",
+        "yaml": "^2.7.1",
         "zod-to-json-schema": "^3.24.4"
       },
       "bin": {
@@ -4347,6 +4348,18 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",
         "commander": "^13.1.0",
-        "playwright": "1.52.0-alpha-1743011787000",
+        "playwright": "^1.52.0-alpha-1743163434000",
         "zod-to-json-schema": "^3.24.4"
       },
       "bin": {
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.19.0",
-        "@playwright/test": "1.52.0-alpha-1743011787000",
+        "@playwright/test": "^1.52.0-alpha-1743163434000",
         "@stylistic/eslint-plugin": "^3.0.1",
         "@types/node": "^22.13.10",
         "@typescript-eslint/eslint-plugin": "^8.26.1",
@@ -285,13 +285,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.52.0-alpha-1743011787000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0-alpha-1743011787000.tgz",
-      "integrity": "sha512-ikJR8JXof5IBvErrmIsR3ixov4nKlQe/6PSYK/R6eTEe6eoT+eEXlaNY4z6mn9dF02Z1zYGxzAbb8TvSvuwh4Q==",
+      "version": "1.52.0-alpha-1743163434000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0-alpha-1743163434000.tgz",
+      "integrity": "sha512-4uBgNlJ6hgPtB8DrwQsgoKuVoe7j+nPqudna7CLXWCmmT3LYPMD5aOjGoBkszr+R9NejtKashq/bOi/ny9hsIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.52.0-alpha-1743011787000"
+        "playwright": "1.52.0-alpha-1743163434000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3296,12 +3296,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.52.0-alpha-1743011787000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0-alpha-1743011787000.tgz",
-      "integrity": "sha512-wg9Tu4ZDKJWo7hBKpeuD/XLtLOQ7fCCuBfekgUrPLStA12O3224E1fbp/xGFnmi47SF71Y8F6C2Beyd3gYFWlQ==",
+      "version": "1.52.0-alpha-1743163434000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0-alpha-1743163434000.tgz",
+      "integrity": "sha512-4uYv49ekPjolydfFfTfFQ2z4URF9UZMVUXLy7aXam/tPxEQ5O7+jQC+yzrDMGmhcj5QkMnxjlyk7N2V9a0QLdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0-alpha-1743011787000"
+        "playwright-core": "1.52.0-alpha-1743163434000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3314,9 +3314,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0-alpha-1743011787000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0-alpha-1743011787000.tgz",
-      "integrity": "sha512-yOpMfKxTBRqdm50b52cojvTCNttWN+Xk6LXF+KU4ufcGwcRjUud1xdHmHHvQNFFanXM1MBYnDKsMkRvjPsuYOw==",
+      "version": "1.52.0-alpha-1743163434000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0-alpha-1743163434000.tgz",
+      "integrity": "sha512-Tn4u3Ywwjkh847/bYWlXIrNxv5DRJRDgtb+VYMXHvNCKkrxL6yfZ1ApIAYD7IAkkKH/KLTXszGWl3a/Z/KDfQA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "commander": "^13.1.0",
     "playwright": "^1.52.0-alpha-1743163434000",
+    "yaml": "^2.7.1",
     "zod-to-json-schema": "^3.24.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "commander": "^13.1.0",
-    "playwright": "1.52.0-alpha-1743011787000",
+    "playwright": "^1.52.0-alpha-1743163434000",
     "zod-to-json-schema": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.19.0",
-    "@playwright/test": "1.52.0-alpha-1743011787000",
+    "@playwright/test": "^1.52.0-alpha-1743163434000",
     "@stylistic/eslint-plugin": "^3.0.1",
+    "@types/node": "^22.13.10",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",
     "@typescript-eslint/utils": "^8.26.1",
-    "@types/node": "^22.13.10",
     "eslint": "^9.19.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-notice": "^1.0.0",

--- a/src/context.ts
+++ b/src/context.ts
@@ -128,7 +128,7 @@ export class Context {
   async allFramesSnapshot() {
     this._lastSnapshotFrames = [];
     const yaml = await this._allFramesSnapshot(this.existingPage());
-    return yaml.toString();
+    return yaml.toString().trim();
   }
 
   private async _allFramesSnapshot(frame: playwright.Page | playwright.FrameLocator): Promise<yaml.Document> {

--- a/src/context.ts
+++ b/src/context.ts
@@ -124,8 +124,10 @@ export class Context {
 
     const visit = async (node: any): Promise<unknown> => {
       if (yaml.isPair(node)) {
-        node.key = await visit(node.key);
-        node.value = await visit(node.value);
+        await Promise.all([
+          visit(node.key).then(k => node.key = k),
+          visit(node.value).then(v => node.value = v)
+        ]);
       } else if (yaml.isSeq(node) || yaml.isMap(node)) {
         node.items = await Promise.all(node.items.map(visit));
       } else if (yaml.isScalar(node)) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -132,7 +132,7 @@ export class Context {
           const ref = node.value.match(/\[ref=(.*)\]/)?.[1];
           if (!ref)
             return;
-          iframes.push([ref, [...path, key]]);
+          iframes.push([ref, [key]]);
         }
 
         if (frameIndex > 0)
@@ -142,7 +142,7 @@ export class Context {
 
     await Promise.all(iframes.map(async ([ref, path]) => {
       const childSnapshot = await this._allFramesSnapshot(frame.frameLocator(`aria-ref=${ref}`));
-      snapshot.setIn(path, snapshot.createPair(snapshot.getIn(path.slice(2)), childSnapshot));
+      snapshot.setIn(path, snapshot.createPair(snapshot.getIn(path), childSnapshot));
     }));
 
     return snapshot;

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -217,21 +217,26 @@ test('stitched aria frames', async ({ client }) => {
   expect(await client.callTool({
     name: 'browser_navigate',
     arguments: {
-      url: 'data:text/html,<h1>Hello</h1><iframe src="data:text/html,<h1>World</h1>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>',
+      url: 'data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>',
     },
   })).toHaveTextContent(`
-- Page URL: data:text/html,<h1>Hello</h1><iframe src="data:text/html,<h1>World</h1>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>
+- Page URL: data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>
 - Page Title: 
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s1e2]:
-  - heading "Hello" [level=1] [ref=s1e4]
-
-# iframe src=data:text/html,<h1>World</h1>
-- document [ref=f0s1e2]:
-  - heading "World" [level=1] [ref=f0s1e4]
+- heading "Hello" [level=1] [ref=s1e3]
+- iframe [ref=s1e4]:
+  - button "World" [ref=f1s1e3]
 \`\`\`
 `);
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'World',
+      ref: 'f1s1e3',
+    },
+  })).toContainTextContent('"World" clicked');
 });
 
 test('browser_choose_file', async ({ client }) => {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -214,13 +214,15 @@ test('stitched aria frames', async ({ client }) => {
   expect(await client.callTool({
     name: 'browser_navigate',
     arguments: {
-      url: 'data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>',
+      url: `data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button><iframe src='data:text/html,<p>Nested</p>'></iframe>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>`,
     },
   })).toContainTextContent(`
 \`\`\`yaml
 - heading "Hello" [level=1] [ref=s1e3]
 - iframe [ref=s1e4]:
     - button "World" [ref=f1s1e3]
+    - iframe [ref=f1s1e4]:
+        - paragraph [ref=f2s1e3]: Nested
 
 \`\`\`
 `);

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -214,15 +214,16 @@ test('stitched aria frames', async ({ client }) => {
   expect(await client.callTool({
     name: 'browser_navigate',
     arguments: {
-      url: `data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button><iframe src='data:text/html,<p>Nested</p>'></iframe>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>`,
+      url: `data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button><main><iframe src='data:text/html,<p>Nested</p>'></iframe></main>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>`,
     },
   })).toContainTextContent(`
 \`\`\`yaml
 - heading "Hello" [level=1] [ref=s1e3]
 - iframe [ref=s1e4]:
     - button "World" [ref=f1s1e3]
-    - iframe [ref=f1s1e4]:
-        - paragraph [ref=f2s1e3]: Nested
+    - main [ref=f1s1e4]:
+        - iframe [ref=f1s1e5]:
+            - paragraph [ref=f2s1e3]: Nested
 
 \`\`\`
 `);

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -157,8 +157,8 @@ test('single option', async ({ client }) => {
 - Page Snapshot
 \`\`\`yaml
 - combobox [ref=s2e3]:
-  - option "Foo" [ref=s2e4]
-  - option "Bar" [selected] [ref=s2e5]
+    - option "Foo" [ref=s2e4]
+    - option "Bar" [selected] [ref=s2e5]
 \`\`\`
 `);
 });
@@ -185,9 +185,9 @@ test('multiple option', async ({ client }) => {
 - Page Snapshot
 \`\`\`yaml
 - listbox [ref=s2e3]:
-  - option "Foo" [ref=s2e4]
-  - option "Bar" [selected] [ref=s2e5]
-  - option "Baz" [selected] [ref=s2e6]
+    - option "Foo" [ref=s2e4]
+    - option "Bar" [selected] [ref=s2e5]
+    - option "Baz" [selected] [ref=s2e6]
 \`\`\`
 `);
 });
@@ -224,7 +224,6 @@ test('stitched aria frames', async ({ client }) => {
     - main [ref=f1s1e4]:
         - iframe [ref=f1s1e5]:
             - paragraph [ref=f2s1e3]: Nested
-
 \`\`\`
 `);
 
@@ -329,7 +328,7 @@ test('cdp server', async ({ cdpEndpoint, startClient }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s1e2]: Hello, world!
+- text: Hello, world!
 \`\`\`
 `
   );

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -77,7 +77,7 @@ test('test browser_navigate', async ({ client }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s1e2]: Hello, world!
+- text: Hello, world!
 \`\`\`
 `
   );
@@ -95,7 +95,7 @@ test('test browser_click', async ({ client }) => {
     name: 'browser_click',
     arguments: {
       element: 'Submit button',
-      ref: 's1e4',
+      ref: 's1e3',
     },
   })).toHaveTextContent(`"Submit button" clicked
 
@@ -103,8 +103,7 @@ test('test browser_click', async ({ client }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s2e2]:
-  - button "Submit" [ref=s2e4]
+- button "Submit" [ref=s2e3]
 \`\`\`
 `);
 });
@@ -131,7 +130,7 @@ test('test reopen browser', async ({ client }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s1e2]: Hello, world!
+- text: Hello, world!
 \`\`\`
 `);
 });
@@ -148,7 +147,7 @@ test('single option', async ({ client }) => {
     name: 'browser_select_option',
     arguments: {
       element: 'Select',
-      ref: 's1e4',
+      ref: 's1e3',
       values: ['bar'],
     },
   })).toHaveTextContent(`Selected option in "Select"
@@ -157,10 +156,9 @@ test('single option', async ({ client }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s2e2]:
-  - combobox [ref=s2e4]:
-    - option "Foo" [ref=s2e5]
-    - option "Bar" [selected] [ref=s2e6]
+- combobox [ref=s2e3]:
+  - option "Foo" [ref=s2e4]
+  - option "Bar" [selected] [ref=s2e5]
 \`\`\`
 `);
 });
@@ -177,7 +175,7 @@ test('multiple option', async ({ client }) => {
     name: 'browser_select_option',
     arguments: {
       element: 'Select',
-      ref: 's1e4',
+      ref: 's1e3',
       values: ['bar', 'baz'],
     },
   })).toHaveTextContent(`Selected option in "Select"
@@ -186,11 +184,10 @@ test('multiple option', async ({ client }) => {
 - Page Title: Title
 - Page Snapshot
 \`\`\`yaml
-- document [ref=s2e2]:
-  - listbox [ref=s2e4]:
-    - option "Foo" [ref=s2e5]
-    - option "Bar" [selected] [ref=s2e6]
-    - option "Baz" [selected] [ref=s2e7]
+- listbox [ref=s2e3]:
+  - option "Foo" [ref=s2e4]
+  - option "Bar" [selected] [ref=s2e5]
+  - option "Baz" [selected] [ref=s2e6]
 \`\`\`
 `);
 });
@@ -245,13 +242,13 @@ test('browser_choose_file', async ({ client }) => {
     arguments: {
       url: 'data:text/html,<html><title>Title</title><input type="file" /><button>Button</button></html>',
     },
-  })).toContainTextContent('- textbox [ref=s1e4]');
+  })).toContainTextContent('- textbox [ref=s1e3]');
 
   expect(await client.callTool({
     name: 'browser_click',
     arguments: {
       element: 'Textbox',
-      ref: 's1e4',
+      ref: 's1e3',
     },
   })).toContainTextContent('There is a file chooser visible that requires browser_choose_file to be called');
 
@@ -267,7 +264,7 @@ test('browser_choose_file', async ({ client }) => {
     });
 
     expect(response).not.toContainTextContent('There is a file chooser visible that requires browser_choose_file to be called');
-    expect(response).toContainTextContent('textbox [ref=s3e4]: C:\\fakepath\\test.txt');
+    expect(response).toContainTextContent('textbox [ref=s3e3]: C:\\fakepath\\test.txt');
   }
 
   {
@@ -275,12 +272,12 @@ test('browser_choose_file', async ({ client }) => {
       name: 'browser_click',
       arguments: {
         element: 'Textbox',
-        ref: 's3e4',
+        ref: 's3e3',
       },
     });
 
     expect(response).toContainTextContent('There is a file chooser visible that requires browser_choose_file to be called');
-    expect(response).toContainTextContent('button "Button" [ref=s4e5]');
+    expect(response).toContainTextContent('button "Button" [ref=s4e4]');
   }
 
   {
@@ -288,7 +285,7 @@ test('browser_choose_file', async ({ client }) => {
       name: 'browser_click',
       arguments: {
         element: 'Button',
-        ref: 's4e5',
+        ref: 's4e4',
       },
     });
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -216,14 +216,12 @@ test('stitched aria frames', async ({ client }) => {
     arguments: {
       url: 'data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>',
     },
-  })).toHaveTextContent(`
-- Page URL: data:text/html,<h1>Hello</h1><iframe src="data:text/html,<button>World</button>"></iframe><iframe src="data:text/html,<h1>Should be invisible</h1>" style="display: none;"></iframe>
-- Page Title: 
-- Page Snapshot
+  })).toContainTextContent(`
 \`\`\`yaml
 - heading "Hello" [level=1] [ref=s1e3]
 - iframe [ref=s1e4]:
-  - button "World" [ref=f1s1e3]
+    - button "World" [ref=f1s1e3]
+
 \`\`\`
 `);
 


### PR DESCRIPTION
Based on https://github.com/microsoft/playwright/pull/35396, we can now stitch the iframes into one tree.

I also changed from `.locator('html').ariaSnapshot()` to `.locator('body').ariaSnapshot()`, so we get a more compact tree.
Here's how it looks with `'html'`:

```yaml
- document [ref=s1e2]:
  - heading "Hello" [level=1] [ref=s1e4]
  - iframe [ref=s1e5]:
    - document [ref=f1s1e2]:
      - button "World" [ref=f1s1e4]
```

And here's with `'body'`:

```yaml
- heading "Hello" [level=1] [ref=s1e3]
- iframe [ref=s1e4]:
  - button "World" [ref=f1s1e3]
```

If I was an LLM, i'd definitely prefer the second!