### PR TITLE
feat : browser_expect_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ The Playwright MCP provides a set of tools for browser automation. Here are all 
   - Description: Close the page
   - Parameters: None
 
+- **browser_expect_text**
+  - Description: Assert that an element contains specific text content
+  - Parameters:
+    - `element` (string): Human-readable element description used to obtain permission to interact with the element
+    - `ref` (string): Exact target element reference from the page snapshot
+    - `expected` (string): Expected text content of the element
+
 
 ### Vision Mode
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ const snapshotTools: Tool[] = [
   snapshot.type,
   snapshot.selectOption,
   snapshot.screenshot,
+  snapshot.expectText,
   ...commonTools,
 ];
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -153,3 +153,38 @@ export const screenshot: Tool = {
     };
   },
 };
+
+const expectTextSchema = elementSchema.extend({
+  expected: z.string().describe('Expected text content of the element'),
+});
+
+export const expectText: Tool = {
+  schema: {
+    name: 'browser_expect_text',
+    description: 'Assert that an element contains specific text content',
+    inputSchema: zodToJsonSchema(expectTextSchema),
+  },
+
+  handle: async (context, params) => {
+    const validatedParams = expectTextSchema.parse(params);
+    const locator = context.refLocator(validatedParams.ref);
+    const actualText = await locator.textContent();
+    
+    if (actualText !== validatedParams.expected) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Assertion failed: Expected text "${validatedParams.expected}" but found "${actualText}" in element "${validatedParams.element}"`,
+        }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Successfully verified text "${validatedParams.expected}" in element "${validatedParams.element}"`,
+      }],
+    };
+  },
+};

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -32,6 +32,7 @@ test('test tool list', async ({ client, visionClient }) => {
     'browser_type',
     'browser_select_option',
     'browser_take_screenshot',
+    'browser_expect_text',
     'browser_press_key',
     'browser_wait',
     'browser_save_as_pdf',
@@ -312,4 +313,36 @@ test('sse transport', async () => {
   } finally {
     cp.kill();
   }
+});
+
+test('test browser_expect_text', async ({ client }) => {
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: 'data:text/html,<html><title>Title</title><div>Hello World</div></html>',
+    },
+  });
+
+
+  expect(await client.callTool({
+    name: 'browser_expect_text',
+    arguments: {
+      element: 'Div element',
+      ref: 's1e4',
+      expected: 'Hello World',
+    },
+  })).toHaveTextContent('Successfully verified text "Hello World" in element "Div element"');
+
+  
+  const response = await client.callTool({
+    name: 'browser_expect_text',
+    arguments: {
+      element: 'Div element',
+      ref: 's1e4',
+      expected: 'Wrong Text',
+    },
+  });
+  
+  expect(response.content[0].text).toContain('Assertion failed');
+  expect(response.isError).toBe(true);
 });


### PR DESCRIPTION
feat: add browser_expect_text tool for text content validation

Add a new browser_expect_text tool that allows asserting specific text
content in web elements. This tool is useful for validation and testing
scenarios where exact text matching is required.

The tool:
- Validates text content of specified elements
- Returns success/failure with detailed messages
- Integrates with the existing snapshot-based interaction model

Changes:
- Add expectText tool implementation in src/tools/snapshot.ts
- Add corresponding test cases in tests/basic.spec.ts
- Update tool list in src/index.ts
- Add documentation in README.md

Example usage:
browser_expect_text({
  element: "Heading",
  ref: "s1e4",
  expected: "Expected Text"
})