### PR TITLE
chore: better description for browser_press_key

### DIFF
--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -106,7 +106,7 @@ const pressKeySchema = z.object({
 export const pressKey: Tool = {
   schema: {
     name: 'browser_press_key',
-    description: 'Press a key on the keyboard',
+    description: 'Press a key on the keyboard. Use to type text one character at a time or to press special keys like ArrowLeft, ArrowRight.',
     inputSchema: zodToJsonSchema(pressKeySchema),
   },
   handle: async (context, params) => {


### PR DESCRIPTION
With current description it's hard to talk LLM into using `browser_press_key` instead of `browser_type`. This makes the following prompt work:

```
Goto https://app.utrsports.net/search?type=players"
Focus in the 'Search' box
Slowly type 'John'.
Wait for 'John' in the drop down list.
```
