### PR TITLE
feat: add slowly option for typing one character at a time

### DIFF
--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -113,7 +113,7 @@ const pressKeySchema = z.object({
 export const pressKey: (captureSnapshot: boolean) => Tool = captureSnapshot => ({
   schema: {
     name: 'browser_press_key',
-    description: 'Press a key on the keyboard',
+    description: 'Press a key on the keyboard.',
     inputSchema: zodToJsonSchema(pressKeySchema),
   },
   handle: async (context, params) => {

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -113,7 +113,7 @@ const pressKeySchema = z.object({
 export const pressKey: (captureSnapshot: boolean) => Tool = captureSnapshot => ({
   schema: {
     name: 'browser_press_key',
-    description: 'Press a key on the keyboard.',
+    description: 'Press a key on the keyboard',
     inputSchema: zodToJsonSchema(pressKeySchema),
   },
   handle: async (context, params) => {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -114,7 +114,7 @@ export const drag: Tool = {
 
 const typeSchema = z.object({
   text: z.string().describe('Text to type into the element'),
-  submit: z.boolean().describe('Whether to submit entered text (press Enter after)'),
+  submit: z.boolean().optional().describe('Whether to submit entered text (press Enter after)'),
 });
 
 export const type: Tool = {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -101,7 +101,7 @@ export const hover: Tool = {
 
 const typeSchema = elementSchema.extend({
   text: z.string().describe('Text to type into the element'),
-  submit: z.boolean().describe('Whether to submit entered text (press Enter after)'),
+  submit: z.boolean().optional().describe('Whether to submit entered text (press Enter after)'),
   slowly: z.boolean().optional().describe('Wether to type one character at a time. Useful for triggering key handlers in the page. By default entire text is filled in at once.'),
 });
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -128,7 +128,7 @@ export const type: Tool = {
   },
 };
 
-const selectSchema = elementSchema.extend({
+const selectOptionSchema = elementSchema.extend({
   values: z.array(z.string()).describe('Array of values to select in the dropdown. This can be a single value or multiple values.'),
 });
 
@@ -136,11 +136,11 @@ export const selectOption: Tool = {
   schema: {
     name: 'browser_select_option',
     description: 'Select an option in a dropdown',
-    inputSchema: zodToJsonSchema(selectSchema),
+    inputSchema: zodToJsonSchema(selectOptionSchema),
   },
 
   handle: async (context, params) => {
-    const validatedParams = selectSchema.parse(params);
+    const validatedParams = selectOptionSchema.parse(params);
     return await context.runAndWaitWithSnapshot(async () => {
       const locator = context.lastSnapshot().refLocator(validatedParams.ref);
       await locator.selectOption(validatedParams.values);

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -102,7 +102,7 @@ export const hover: Tool = {
 const typeSchema = elementSchema.extend({
   text: z.string().describe('Text to type into the element'),
   submit: z.boolean().describe('Whether to submit entered text (press Enter after)'),
-  slowly: z.boolean().describe('Wether to type one character at a time. Useful for triggering key handlers in the page. By default entire text is filled in at once.'),
+  slowly: z.boolean().optional().describe('Wether to type one character at a time. Useful for triggering key handlers in the page. By default entire text is filled in at once.'),
 });
 
 export const type: Tool = {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -373,7 +373,7 @@ test('fill in text', async ({ client }) => {
   await client.callTool({
     name: 'browser_navigate',
     arguments: {
-      url: `data:text/html,<input type='text' onkeydown="console.log('Key pressed:', event.key, ', Text:', event.target.value)"></input>`,
+      url: `data:text/html,<input type='keypress' onkeypress="console.log('Key pressed:', event.key, ', Text:', event.target.value)"></input>`,
     },
   });
   await client.callTool({

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -369,11 +369,37 @@ test('executable path', async ({ startClient }) => {
   expect(response).toContainTextContent(`executable doesn't exist`);
 });
 
+test('fill in text', async ({ client }) => {
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: `data:text/html,<input type='text' onkeydown="console.log('Key pressed:', event.key, ', Text:', event.target.value)"></input>`,
+    },
+  });
+  await client.callTool({
+    name: 'browser_type',
+    arguments: {
+      element: 'textbox',
+      ref: 's1e3',
+      text: 'Hi!',
+      submit: true,
+    },
+  });
+  const resource = await client.readResource({
+    uri: 'browser://console',
+  });
+  expect(resource.contents).toEqual([{
+    uri: 'browser://console',
+    mimeType: 'text/plain',
+    text: '[LOG] Key pressed: Enter , Text: Hi!',
+  }]);
+});
+
 test('type slowly', async ({ client }) => {
   await client.callTool({
     name: 'browser_navigate',
     arguments: {
-      url: `data:text/html,<input type='text' onkeydown="console.log('Key pressed:', event.key)"></input>`,
+      url: `data:text/html,<input type='text' onkeydown="console.log('Key pressed:', event.key, 'Text:', event.target.value)"></input>`,
     },
   });
   await client.callTool({
@@ -393,10 +419,10 @@ test('type slowly', async ({ client }) => {
     uri: 'browser://console',
     mimeType: 'text/plain',
     text: [
-      '[LOG] Key pressed: H',
-      '[LOG] Key pressed: i',
-      '[LOG] Key pressed: !',
-      '[LOG] Key pressed: Enter'
+      '[LOG] Key pressed: H Text: ',
+      '[LOG] Key pressed: i Text: H',
+      '[LOG] Key pressed: ! Text: Hi',
+      '[LOG] Key pressed: Enter Text: Hi!',
     ].join('\n'),
   }]);
 });

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -368,3 +368,35 @@ test('executable path', async ({ startClient }) => {
   });
   expect(response).toContainTextContent(`executable doesn't exist`);
 });
+
+test('type slowly', async ({ client }) => {
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: `data:text/html,<input type='text' onkeydown="console.log('Key pressed:', event.key)"></input>`,
+    },
+  });
+  await client.callTool({
+    name: 'browser_type',
+    arguments: {
+      element: 'textbox',
+      ref: 's1e3',
+      text: 'Hi!',
+      submit: true,
+      slowly: true,
+    },
+  });
+  const resource = await client.readResource({
+    uri: 'browser://console',
+  });
+  expect(resource.contents).toEqual([{
+    uri: 'browser://console',
+    mimeType: 'text/plain',
+    text: [
+      '[LOG] Key pressed: H',
+      '[LOG] Key pressed: i',
+      '[LOG] Key pressed: !',
+      '[LOG] Key pressed: Enter'
+    ].join('\n'),
+  }]);
+});


### PR DESCRIPTION
With current description it's hard to talk LLM into using `browser_press_key` instead of `browser_type`. This makes the following prompt work:

```
Goto https://app.utrsports.net/search?type=players"
Focus in the 'Search' box
Slowly type 'John'.
Wait for 'John' in the drop down list.
```
