### PR TITLE
fix: exit watchdog should listen for SIGINT/SIGTERM

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -100,11 +100,15 @@ program
     });
 
 function setupExitWatchdog(serverList: ServerList) {
-  process.stdin.on('close', async () => {
+  const handleExit = async () => {
     setTimeout(() => process.exit(0), 15000);
     await serverList.closeAll();
     process.exit(0);
-  });
+  };
+
+  process.stdin.on('close', handleExit);
+  process.on('SIGINT', handleExit);
+  process.on('SIGTERM', handleExit);
 }
 
 program.parse(process.argv);


### PR DESCRIPTION
The `StdioClientTransport` implementation sends SIGTERM upon calling `close()`, but it looks like they don't close the Stdin pipe. This PR adds `SIGTERM` and `SIGINT` signals as triggers to our exit routine.

Closes https://github.com/microsoft/playwright-mcp/issues/141

It's hard to test this because of https://github.com/modelcontextprotocol/typescript-sdk/issues/271, sadly.