### PR TITLE
Restore `package-lock.json` module hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,8 @@
     },
     "node_modules/@types/node": {
       "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1019,6 +1021,8 @@
     },
     "node_modules/commander": {
       "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4188,6 +4192,8 @@
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4376,6 +4382,8 @@
     },
     "node_modules/zod": {
       "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -4383,6 +4391,8 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.4.tgz",
+      "integrity": "sha512-0uNlcvgabyrni9Ag8Vghj21drk7+7tp7VTwwR7KxxXXc/3pbXz2PHlDgj3cICahgF1kHm4dExBFj7BXrZJXzig==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"


### PR DESCRIPTION
- Adds integrity hashes that were missing for 5 npm packages in `package-lock.json`

<hr />

Is there a reason hashes for some of these dependencies are missing from `package-lock.json`?

Right now these omissions prevent me from packaging a nix derivation for this mcp server directly off this repo (https://github.com/cameronfyfe/nix-mcp-servers/blob/main/pkgs/servers/mcp-server-playwright/default.nix#L17) and I was wondering if they might just be missing due to a bad merge or something odd like that at some point. `npm install` under normal use doesn't seem to care if the hashes are missing and installs the packages anyway, but it's a blocker for hermetic build systems like nix.

If this is intentional for some reason I'm not familiar with feel free to ignore and close.