### PR TITLE
Add element screenshot action for snapshots

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -173,6 +173,12 @@ export class Context {
 
 type RunResult = {
   code: string[];
+  images?: ImageContent[];
+};
+
+type ImageContent = {
+  data: string;
+  mimeType: string;
 };
 
 class Tab {
@@ -240,8 +246,16 @@ ${runResult.code.join('\n')}
       result.push(this._snapshot.text({ hasFileChooser: !!this._fileChooser }));
     }
 
+    const images = runResult.images?.map(image => {
+      return {
+        type: 'image' as 'image',
+        data: image.data,
+        mimeType: image.mimeType,
+      };
+    }) ?? [];
+
     return {
-      content: [{
+      content: [...images, {
         type: 'text',
         text: result.join('\n'),
       }],

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -209,9 +209,15 @@ const screenshot: Tool = {
     } else {
       return await context.currentTab().runAndWaitWithSnapshot(async snapshot => {
         const locator = snapshot.refLocator(validatedParams.ref);
+        const code = [
+          `// Screenshot ${validatedParams.element}`,
+          `await page.${await generateLocator(locator)}.screenshot(${javascript.formatObject(options)});`
+        ];
         await locator.screenshot(options);
-      }, {
-        status: `Saved as "${fileName}"`,
+        code.push(`// Saved as ${fileName}`);
+        return {
+          code
+        };
       });
     }
     return {

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -33,6 +33,7 @@ test('test snapshot tool list', async ({ client }) => {
     'browser_pdf_save',
     'browser_press_key',
     'browser_resize',
+    'browser_screenshot_element',
     'browser_snapshot',
     'browser_tab_close',
     'browser_tab_list',

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -33,7 +33,6 @@ test('test snapshot tool list', async ({ client }) => {
     'browser_pdf_save',
     'browser_press_key',
     'browser_resize',
-    'browser_screenshot_element',
     'browser_snapshot',
     'browser_tab_close',
     'browser_tab_list',


### PR DESCRIPTION
Pull request to allow taking screenshots of specific elements on the screen rather than the whole screen.

Also, changed the current screenshot taking to instead save the screenshot to a temp location. Doing this because the current implementation of returning an ImageContent result does not work with most MCP agents. This is also following the PDF implementation, which also exports to a file.

For large screenshots, it can also happen that the buffer is too large for agents, so saving to a file is preferred as to not lose the screenshot due to an image that is too big to be output in the chat.