### PR TITLE
chore: turn file chooser into block reason

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -214,7 +214,7 @@ class Tab {
   }
 
   async run(callback: (tab: Tab) => Promise<RunResult>, options?: RunOptions): Promise<ToolResult> {
-    const blockedBeforeAction = this.blockReason(options);
+    const blockedBeforeAction = this._blockReason(options);
     if (blockedBeforeAction) {
       return {
         content: [{
@@ -238,7 +238,7 @@ class Tab {
     const result: string[] = [];
     result.push('', '- Ran code:', '```js', ...runResult.code, '```', '');
 
-    const blockedAfterAction = this.blockReason();
+    const blockedAfterAction = this._blockReason();
     if (blockedAfterAction)
       result.push(blockedAfterAction, '');
 
@@ -297,7 +297,7 @@ class Tab {
     this._fileChooser = undefined;
   }
 
-  blockReason(options?: RunOptions): string | undefined {
+  private _blockReason(options?: RunOptions): string | undefined {
     if (this._fileChooser && !options?.noClearFileChooser)
       return '- The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.';
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,6 +19,7 @@ import yaml from 'yaml';
 
 import { waitForCompletion } from './tools/utils';
 import { ToolResult } from './tools/tool';
+import { uploadFile } from './tools/files';
 
 export type ContextOptions = {
   browserName?: 'chromium' | 'firefox' | 'webkit';
@@ -301,7 +302,7 @@ class Tab {
 
   private _blockReason(options?: RunOptions): string | undefined {
     if (this._fileChooser && !options?.ignoreBlocks?.filechooser)
-      return '- The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.';
+      return `- The page opened a file chooser. Use ${uploadFile(true).schema.name} to submit files or dismiss it before continuing.`;
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -33,7 +33,9 @@ type PageOrFrameLocator = playwright.Page | playwright.FrameLocator;
 type RunOptions = {
   captureSnapshot?: boolean;
   waitForCompletion?: boolean;
-  noClearFileChooser?: boolean;
+  ignoreBlocks?: {
+    filechooser?: boolean;
+  };
 };
 
 export class Context {
@@ -298,7 +300,7 @@ class Tab {
   }
 
   private _blockReason(options?: RunOptions): string | undefined {
-    if (this._fileChooser && !options?.noClearFileChooser)
+    if (this._fileChooser && !options?.ignoreBlocks?.filechooser)
       return '- The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.';
   }
 }

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -46,7 +46,9 @@ const uploadFile: ToolFactory = captureSnapshot => ({
       return { code };
     }, {
       captureSnapshot,
-      noClearFileChooser: true,
+      ignoreBlocks: {
+        filechooser: true,
+      },
     });
   },
 });

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -23,7 +23,7 @@ const uploadFileSchema = z.object({
   paths: z.array(z.string()).describe('The absolute paths to the files to upload. Can be a single file or multiple files. Pass empty array to dismiss the file chooser.'),
 });
 
-const uploadFile: ToolFactory = captureSnapshot => ({
+export const uploadFile: ToolFactory = captureSnapshot => ({
   capability: 'files',
   schema: {
     name: 'browser_file_upload',

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -20,7 +20,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ToolFactory } from './tool';
 
 const uploadFileSchema = z.object({
-  paths: z.array(z.string()).describe('The absolute paths to the files to upload. Can be a single file or multiple files.'),
+  paths: z.array(z.string()).describe('The absolute paths to the files to upload. Can be a single file or multiple files. Pass empty array to dismiss the file chooser.'),
 });
 
 const uploadFile: ToolFactory = captureSnapshot => ({
@@ -34,9 +34,14 @@ const uploadFile: ToolFactory = captureSnapshot => ({
     const validatedParams = uploadFileSchema.parse(params);
     const tab = context.currentTab();
     return await tab.runAndWait(async () => {
+      if (validatedParams.paths.length === 0) {
+        await tab.dismissFileChooser();
+        return { code: ['// <internal code to dismiss the file chooser>'] };
+      }
+
       await tab.submitFileChooser(validatedParams.paths);
       const code = [
-        `// <internal code to chose files ${validatedParams.paths.join(', ')}`,
+        `// <internal code to choose files ${validatedParams.paths.join(', ')} >`,
       ];
       return { code };
     }, {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -152,7 +152,7 @@ test('browser_file_upload', async ({ client }) => {
       element: 'Textbox',
       ref: 's1e3',
     },
-  })).toContainTextContent('There is a file chooser visible that requires browser_file_upload to be called');
+  })).toContainTextContent('The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.');
 
   const filePath = test.info().outputPath('test.txt');
   await fs.writeFile(filePath, 'Hello, world!');
@@ -165,7 +165,7 @@ test('browser_file_upload', async ({ client }) => {
       },
     });
 
-    expect(response).not.toContainTextContent('There is a file chooser visible that requires browser_file_upload to be called');
+    expect(response).not.toContainTextContent('The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.');
     expect(response).toContainTextContent('textbox [ref=s3e3]: C:\\fakepath\\test.txt');
   }
 
@@ -178,7 +178,7 @@ test('browser_file_upload', async ({ client }) => {
       },
     });
 
-    expect(response).toContainTextContent('There is a file chooser visible that requires browser_file_upload to be called');
+    expect(response).toContainTextContent('The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.');
     expect(response).toContainTextContent('button "Button" [ref=s4e4]');
   }
 
@@ -191,7 +191,18 @@ test('browser_file_upload', async ({ client }) => {
       },
     });
 
-    expect(response, 'not submitting browser_file_upload dismisses file chooser').not.toContainTextContent('There is a file chooser visible that requires browser_file_upload to be called');
+    expect(response, 'not submitting browser_file_upload gets blocked').toHaveTextContent('- The page opened a file chooser. Use browser_file_upload to submit files or dismiss it before continuing.');
+  }
+
+  {
+    const response = await client.callTool({
+      name: 'browser_file_upload',
+      arguments: {
+        paths: [],
+      },
+    });
+
+    expect(response, 'empty paths dismisses').toContainTextContent('<internal code to dismiss the file chooser>');
   }
 });
 


### PR DESCRIPTION
Turns the file chooser into a block reason. If a page is blocked, it can't be interacted with until it's unblocked. This leads towards https://github.com/microsoft/playwright-mcp/issues/161.