### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-bookworm-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json at this stage to leverage the build cache
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Install chromium and its dependencies, but only for headless mode
+RUN npx -y playwright install --with-deps --only-shell chromium
+
+# Copy the rest of the app
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Run in headless and only with chromium (other browsers need more dependencies not included in this image)
+ENTRYPOINT ["node", "cli.js", "--headless", "--browser", "chromium"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A Model Context Protocol (MCP) server that provides browser automation capabilit
 
 ### Example config
 
+#### NPX
+
 ```js
 {
   "mcpServers": {
@@ -30,6 +32,19 @@ A Model Context Protocol (MCP) server that provides browser automation capabilit
 }
 ```
 
+#### Docker
+
+**NOTE:** The Docker implementation only supports headless chromium at the moment.
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "--init", "mcp/playwright"]
+    }
+  }
+}
+```
 
 #### Installation in VS Code
 
@@ -153,6 +168,13 @@ To use Vision Mode, add the `--vision` flag when starting the server:
 
 Vision Mode works best with the computer use models that are able to interact with elements using
 X Y coordinate space, based on the provided screenshot.
+
+### Build with Docker
+
+You can build the Docker image yourself.
+```
+docker build -t mcp/playwright .
+```
 
 ### Programmatic usage with custom transports
 


### PR DESCRIPTION
This adds a Dockerfile and updates the readme with instructions on how to run this MCP server with Docker. For more context on why this is helpful, [refer to this](https://github.com/modelcontextprotocol/servers/pull/368#issue-2746037642).

**Note**:  The`mcp/playwright` image does not yet exist on Docker Hub, but we'll be adding it soon. In the meantime, it can be built from the repo with `docker build -t mcp/playwright .`