### PR TITLE
feat: add stealth option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "commander": "^13.1.0",
     "playwright": "^1.52.0-alpha-1743163434000",
+    "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "yaml": "^2.7.1",
     "zod-to-json-schema": "^3.24.4"
   },

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,6 +15,9 @@
  */
 
 import * as playwright from 'playwright';
+import { chromium } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+
 import yaml from 'yaml';
 
 import { waitForCompletion } from './tools/utils';
@@ -23,12 +26,15 @@ import { ManualPromise } from './manualPromise';
 import type { ImageContent, TextContent } from '@modelcontextprotocol/sdk/types';
 import type { ModalState, Tool, ToolActionResult } from './tools/tool';
 
+chromium.use(StealthPlugin());
+
 export type ContextOptions = {
   browserName?: 'chromium' | 'firefox' | 'webkit';
   userDataDir: string;
   launchOptions?: playwright.LaunchOptions;
   cdpEndpoint?: string;
   remoteEndpoint?: string;
+  stealth?: boolean;
 };
 
 type PageOrFrameLocator = playwright.Page | playwright.FrameLocator;
@@ -303,7 +309,7 @@ ${code.join('\n')}
 
   private async _launchPersistentContext(): Promise<playwright.BrowserContext> {
     try {
-      const browserType = this.options.browserName ? playwright[this.options.browserName] : playwright.chromium;
+      const browserType = this.options.stealth ? chromium : this.options.browserName ? playwright[this.options.browserName] : playwright.chromium;
       return await browserType.launchPersistentContext(this.options.userDataDir, this.options.launchOptions);
     } catch (error: any) {
       if (error.message.includes('Executable doesn\'t exist'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ type Options = {
   cdpEndpoint?: string;
   vision?: boolean;
   capabilities?: ToolCapability[];
+  stealth?: boolean;
 };
 
 const packageJSON = require('../package.json');
@@ -120,6 +121,7 @@ export async function createServer(options?: Options): Promise<Server> {
     userDataDir,
     launchOptions,
     cdpEndpoint: options?.cdpEndpoint,
+    stealth: !!options?.stealth,
   });
 }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -40,6 +40,7 @@ program
     .option('--port <port>', 'Port to listen on for SSE transport.')
     .option('--user-data-dir <path>', 'Path to the user data directory')
     .option('--vision', 'Run server that uses screenshots (Aria snapshots are used by default)')
+    .option('--stealth', 'Enable stealth mode for the browser to avoid detection.')
     .action(async options => {
       const serverList = new ServerList(() => createServer({
         browser: options.browser,
@@ -49,6 +50,7 @@ program
         vision: !!options.vision,
         cdpEndpoint: options.cdpEndpoint,
         capabilities: options.caps?.split(',').map((c: string) => c.trim() as ToolCapability),
+        stealth: options.stealth,
       }));
       setupExitWatchdog(serverList);
 


### PR DESCRIPTION
The PR adds a "stealth" option to bypass bot detection, allowing agents using the Playwright MCP server to navigate the web without being blocked by CAPTCHAs and other bot prevention measures. 

It integrates stealth functionality using the [puppeteer-extra-plugin-stealth](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth) plugin.