### PR TITLE
fix: show custom error for modal state

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -66,6 +66,8 @@ export class Context {
 
   modalStatesMarkdown(): string[] {
     const result: string[] = ['### Modal state'];
+    if (this._modalStates.length === 0)
+      result.push('- There is no modal state present');
     for (const state of this._modalStates) {
       const tool = this.tools.find(tool => tool.clearsModalState === state.type);
       result.push(`- [${state.description}]: can be handled by the "${tool?.schema.name}" tool`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,33 +49,25 @@ export function createServerWithTools(options: Options): Server {
   });
 
   server.setRequestHandler(CallToolRequestSchema, async request => {
+    const errorResult = (...messages: string[]) => ({
+      content: [{ type: 'text', text: messages.join('\n') }],
+      isError: true,
+    });
     const tool = tools.find(tool => tool.schema.name === request.params.name);
-    if (!tool) {
-      return {
-        content: [{ type: 'text', text: `Tool "${request.params.name}" not found` }],
-        isError: true,
-      };
-    }
+    if (!tool)
+      return errorResult(`Tool "${request.params.name}" not found`);
+
 
     const modalStates = context.modalStates().map(state => state.type);
-    if (modalStates.length && (!tool.clearsModalState || !modalStates.includes(tool.clearsModalState))) {
-      const text = [
-        `Tool "${request.params.name}" does not handle the modal state.`,
-        ...context.modalStatesMarkdown(),
-      ].join('\n');
-      return {
-        content: [{ type: 'text', text }],
-        isError: true,
-      };
-    }
+    if (tool.clearsModalState && !modalStates.includes(tool.clearsModalState))
+      return errorResult(`The tool "${request.params.name}" can only be used when there is related modal state present.`, ...context.modalStatesMarkdown());
+    if (!tool.clearsModalState && modalStates.length)
+      return errorResult(`Tool "${request.params.name}" does not handle the modal state.`, ...context.modalStatesMarkdown());
 
     try {
       return await context.run(tool, request.params.arguments);
     } catch (error) {
-      return {
-        content: [{ type: 'text', text: String(error) }],
-        isError: true,
-      };
+      return errorResult(String(error));
     }
   });
 

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -29,7 +29,11 @@ test('browser_file_upload', async ({ client }) => {
     expect(await client.callTool({
       name: 'browser_file_upload',
       arguments: { paths: [] },
-    })).toHaveTextContent('Error: No file chooser visible');
+    })).toHaveTextContent(`
+The tool "browser_file_upload" can only be used when there is related modal state present.
+### Modal state
+- There is no modal state present
+      `.trim());
   }
 
   expect(await client.callTool({


### PR DESCRIPTION
Calling a tool that resolves modal state, when there's no such modal state visible, currently shows this misleading message:

```md
Tool "browser_file_upload" does not handle the modal state.
### Modal state
```

Instead, we should show the error message from the tool implementation.