### PR TITLE
feat: add request and response body on network tool

### DIFF
--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -47,12 +47,7 @@ const requests = defineTool({
 
 // Only include request/response body for XHR/fetch/json requests
 function shouldIncludeBody(request: playwright.Request): boolean {
-  const resourceType = request.resourceType();
-  if (resourceType === 'xhr' || resourceType === 'fetch')
-    return true;
   const headers = request.headers();
-  if (headers['x-requested-with']?.toLowerCase() === 'xmlhttprequest')
-    return true;
   return request.isNavigationRequest() === false &&
          (headers.accept?.includes('application/json') ||
           headers['content-type']?.includes('application/json'));

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -36,7 +36,7 @@ const requests = defineTool({
       code: [`// <internal code to list network requests>`],
       action: async () => {
         return {
-          content: [{ type: 'text', text: log.join('\n') }]
+          content: [{ type: 'text', text: log }]
         };
       },
       captureSnapshot: false,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -24,7 +24,7 @@ const requests = defineTool({
 
   schema: {
     name: 'browser_network_requests',
-    description: 'Returns all network requests since loading the page, if the request is a xhr or fetch, it will return the request body and response body',
+    description: 'Returns all network requests since loading the page',
     inputSchema: z.object({}),
   },
 

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -33,7 +33,7 @@ const requests = defineTool({
     const allRequests = [...requests.entries()];
     const log = await Promise.all(allRequests.map(async ([request, response]) => await renderRequest(request, response)));
     return {
-      code: ['// <internal code to list all network requests>'],
+      code: [`// <internal code to list all network requests>`],
       action: async () => {
         return {
           content: [{ type: 'text', text: log }]

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -36,7 +36,7 @@ const requests = defineTool({
       code: [`// <internal code to list network requests>`],
       action: async () => {
         return {
-          content: [{ type: 'text', text: log }]
+          content: [{ type: 'text', text: log.join('\n') }]
         };
       },
       captureSnapshot: false,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -33,7 +33,7 @@ const requests = defineTool({
     const allRequests = [...requests.entries()];
     const log = await Promise.all(allRequests.map(async ([request, response]) => await renderRequest(request, response)));
     return {
-      code: [`// <internal code to list all network requests>`],
+      code: [`// <internal code to list network requests>`],
       action: async () => {
         return {
           content: [{ type: 'text', text: log.join('\n') }]

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -36,7 +36,7 @@ const requests = defineTool({
       code: ['// <internal code to list all network requests>'],
       action: async () => {
         return {
-          content: [{ type: 'text', text: log.join('\n') }]
+          content: [{ type: 'text', text: log }]
         };
       },
       captureSnapshot: false,

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -31,7 +31,7 @@ const requests = defineTool({
   handle: async context => {
     const requests = context.currentTabOrDie().requests();
     const allRequests = [...requests.entries()];
-    const log = await Promise.all(allRequests.map(async ([request, response]) => renderRequest(request, response)));
+    const log = await Promise.all(allRequests.map(async ([request, response]) => await renderRequest(request, response)));
     return {
       code: ['// <internal code to list all network requests>'],
       action: async () => {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -47,7 +47,7 @@ const requests = defineTool({
 
 function shouldIncludeBody(request: playwright.Request): boolean {
   const headers = request.headers();
-  return headers['content-type']?.includes('application/json')
+  return headers['content-type']?.includes('application/json');
 }
 
 async function renderRequest(request: playwright.Request, response: playwright.Response | null): Promise<string> {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -24,7 +24,7 @@ const requests = defineTool({
 
   schema: {
     name: 'browser_network_requests',
-    description: 'Returns network requests since loading the page',
+    description: 'Returns all network requests since loading the page, if the request is a xhr or fetch, it will return the request body and response body',
     inputSchema: z.object({}),
   },
 

--- a/tests/network.spec.ts
+++ b/tests/network.spec.ts
@@ -79,7 +79,7 @@ test('browser_network_requests_with_bodies', async ({ client, server }) => {
   });
 
   server.route('/query', (req, res) => {
-    const url = new URL(req.url!, `http://${req.headers.host}`);
+    const url = new URL(req.url || '', `http://${req.headers.host}`);
     const param1 = url.searchParams.get('param1');
     const param2 = url.searchParams.get('param2');
     res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/tests/network.spec.ts
+++ b/tests/network.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { test, expect } from './fixtures';
-import { Buffer } from "node:buffer";
+import { Buffer } from 'node:buffer';
 
 test('browser_network_requests_post_xhr', async ({ client, server }) => {
   server.route('/', (req, res) => {
@@ -47,22 +47,29 @@ test('browser_network_requests_post_xhr', async ({ client, server }) => {
     },
   });
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`[POST] http://localhost:${server.PORT}/json`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain(`${server.PORT}/json`);
 
-  // Check if request body is displayed
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`Request Body: {"data":"test payload"}`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain('test payload');
 
-  // Check if response body is displayed
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`Response Body: {"name":"John Doe"}`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain('John Doe');
 });
 
 test('browser_network_requests_with_bodies', async ({ client, server }) => {
@@ -99,20 +106,29 @@ test('browser_network_requests_with_bodies', async ({ client, server }) => {
     },
   });
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`[GET] http://localhost:${server.PORT}/query?param1=value1&param2=value2`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain(`[GET] http://localhost:${server.PORT}/query?param1=value1&param2=value2`);
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).not.toHaveTextContent(`Request Body:`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).not.toContain('Request Body:');
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`Response Body: {"received":{"param1":"value1","param2":"value2"}}`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain('value1');
 });
 
 test('browser_network_requests_non_xhr', async ({ client, server }) => {
@@ -159,38 +175,59 @@ test('browser_network_requests_non_xhr', async ({ client, server }) => {
   });
 
   // script, style, image requests should be present
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`[GET] http://localhost:${server.PORT}/script.js`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain(`[GET] http://localhost:${server.PORT}/script.js`);
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`[GET] http://localhost:${server.PORT}/style.css`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain(`[GET] http://localhost:${server.PORT}/style.css`);
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).toHaveTextContent(`[GET] http://localhost:${server.PORT}/image.png`);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).toContain(`[GET] http://localhost:${server.PORT}/image.png`);
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).not.toHaveTextContent(jsContent);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).not.toContain('Script loaded');
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).not.toHaveTextContent(cssContent);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).not.toContain('red');
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).not.toHaveTextContent(imgContent);
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).not.toContain('fake image data');
 
-  expect.poll(() => client.callTool({
-    name: 'browser_network_requests',
-    arguments: {},
-  })).not.toHaveTextContent('Response Body:');
+  await expect.poll(async () => {
+    const result = await client.callTool({
+      name: 'browser_network_requests',
+      arguments: {},
+    });
+    return JSON.stringify(result);
+  }).not.toContain('Response Body:');
 });

--- a/tests/network.spec.ts
+++ b/tests/network.spec.ts
@@ -65,7 +65,7 @@ test('browser_network_requests_post_xhr', async ({ client, server }) => {
   })).toHaveTextContent(`Response Body: {"name":"John Doe"}`);
 });
 
-test('browser_network_requests_get_xhr', async ({ client, server }) => {
+test('browser_network_requests_with_bodies', async ({ client, server }) => {
   server.route('/', (req, res) => {
     res.writeHead(200, { 'Content-Type': 'text/html' });
     res.end(`<button onclick="fetch('/query?param1=value1&param2=value2')">GET with params</button>`);


### PR DESCRIPTION
## Background

Closes https://github.com/microsoft/playwright-mcp/issues/271

## Details

- I modified `network.ts` to enable it to return `request` and `response` body information
    - And it returns only `xhr` or `fetch` request, because the context window is not so big, so big CSS and fonts are a waste of space
- I added the test on `network.spec.ts`
