### PR TITLE
chore(gitignore): Add .idea and .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ lib/
 node_modules/
 test-results/
 .vscode/mcp.json
+
+.idea
+.DS_Store


### PR DESCRIPTION
This commit adds .idea and .DS_Store to the .gitignore file to prevent these files from being tracked by Git. These files are typically generated by development environments and operating systems, and excluding them helps maintain a clean repository and avoid unnecessary commits.