### PR TITLE
Support for configuring playwright environment via CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ const screenshotTools: Tool<any>[] = [
 
 type Options = {
   browser?: string;
+  browserOption?: string[];
   userDataDir?: string;
   headless?: boolean;
   executablePath?: string;
@@ -107,6 +108,7 @@ export async function createServer(options?: Options): Promise<Server> {
   const userDataDir = options?.userDataDir ?? await createUserDataDir(browserName);
 
   const launchOptions: LaunchOptions = {
+    args: options?.browserOption,
     headless: !!(options?.headless ?? (os.platform() === 'linux' && !process.env.DISPLAY)),
     channel,
     executablePath: options?.executablePath,

--- a/src/program.ts
+++ b/src/program.ts
@@ -45,7 +45,7 @@ program
     .action(async options => {
       const serverList = new ServerList(() => createServer({
         browser: options.browser,
-        browserOption: options.browserOption?.split(',').map((c: string) => c.trim()),
+        browserOption: options.browserOption?.split(',').map((c: string) => `--${c.trim()}`),
         userDataDir: options.userDataDir,
         headless: options.headless,
         executablePath: options.executablePath,

--- a/src/program.ts
+++ b/src/program.ts
@@ -33,6 +33,7 @@ program
     .version('Version ' + packageJSON.version)
     .name(packageJSON.name)
     .option('--browser <browser>', 'Browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
+    .option('--browser-option <browserOption>', 'Comma-separated list of browser options to use.')
     .option('--caps <caps>', 'Comma-separated list of capabilities to enable, possible values: tabs, pdf, history, wait, files, install. Default is all.')
     .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
     .option('--executable-path <path>', 'Path to the browser executable.')
@@ -44,6 +45,7 @@ program
     .action(async options => {
       const serverList = new ServerList(() => createServer({
         browser: options.browser,
+        browserOption: options.browserOption?.split(',').map((c: string) => c.trim()),
         userDataDir: options.userDataDir,
         headless: options.headless,
         executablePath: options.executablePath,


### PR DESCRIPTION
## Description

This PR adds a new CLI option `--browser-option` to configure additional browser launch arguments.

The `--browser-option` flag accepts a comma-separated list of options.  
For example:

```bash
npx @playwright/mcp --browser-option disable-web-security,no-sandbox
```

## Related Issue

Closes #272

> _As a developer writing automation software, I would like to be able to explicitly configure the Playwright environment.  
> For example — to configure CORS bypass I need to set `bypassCSP` option and `--disable-web-security` launch option._

This PR implements the ability to configure the Playwright environment via CLI parameters, as requested in the linked issue.

---

## TODO
- [ ] [browser option](https://peter.sh/experiments/chromium-command-line-switches/)
- [ ] [Playwright Test Option](https://playwright.dev/docs/test-use-options)
- [ ] Add tests for new CLI options
- [ ] Update documentation (`README.md`)

---

## Motivation

Allow users and automation developers to flexibly configure the Playwright environment at launch time.


---

## Note

This PR is currently in draft state to gather feedback and complete the remaining tasks listed above.