### PR TITLE
test: fix 'reuse first tab when navigating' test on macOS

### DIFF
--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -97,7 +97,6 @@ export const test = baseTest.extend<TestFixtures, WorkerFixtures>({
       `--no-first-run`,
       `--no-sandbox`,
       `--headless`,
-      '--use-mock-keychain',
       `data:text/html,hello world`,
     ], {
       stdio: 'pipe',


### PR DESCRIPTION
This fixes the following which was appearing when running `npm run ctest --workers=1  tests/tabs.spec.ts:144` on my mac machine. We have the same switch in our upstream switches.