### PR TITLE
fix: require is not defined

### DIFF
--- a/src/tools/install.ts
+++ b/src/tools/install.ts
@@ -20,6 +20,9 @@ import path from 'path';
 import { z } from 'zod';
 import { defineTool } from './tool.js';
 
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
 const install = defineTool({
   capability: 'install',
   schema: {


### PR DESCRIPTION
Since it's moved to ESM, `require` isn't defined.
This hotfix is just recreating `require` to workaround this issue.

## Issue
```
❯ npx @wong2/mcp-cli -- npx @playwright/mcp@0.0.19 --browser chromium
✔ Connected, server capabilities: tools
✔ Pick a primitive › tool(browser_install)
✔ Using tool browser_install...
{
  content: [ { type: 'text', text: 'ReferenceError: require is not defined' } ],
  isError: true
}
```

We've applied the same fix to our own patch and it works fine.
https://github.com/autifyhq/aethr-playwright-mcp