### PR TITLE
Chore: Set `outputDir` via cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The Playwright MCP server supports the following command-line options:
 - `--port <port>`: Port to listen on for SSE transport
 - `--host <host>`: Host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.
 - `--vision`: Run server that uses screenshots (Aria snapshots are used by default)
+- `--output-dir`: Directory for output files
 - `--config <path>`: Path to the configuration file
 
 ### User profile

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export type CLIOptions = {
   host?: string;
   vision?: boolean;
   config?: string;
+  outputDir?: string;
 };
 
 const defaultConfig: Config = {
@@ -110,6 +111,7 @@ export async function configFromCLIOptions(cliOptions: CLIOptions): Promise<Conf
     },
     capabilities: cliOptions.caps?.split(',').map((c: string) => c.trim() as ToolCapability),
     vision: !!cliOptions.vision,
+    outputDir: cliOptions.outputDir,
   };
 }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -38,6 +38,7 @@ program
     .option('--port <port>', 'Port to listen on for SSE transport.')
     .option('--host <host>', 'Host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.')
     .option('--vision', 'Run server that uses screenshots (Aria snapshots are used by default)')
+    .option('--output-dir <path>', 'Path to the directory for output files.')
     .option('--config <path>', 'Path to the configuration file.')
     .action(async options => {
       const config = await resolveConfig(options);

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -73,6 +73,28 @@ test('browser_take_screenshot (element)', async ({ client }) => {
   });
 });
 
+test('--output-dir should work', async ({ startClient }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const client = await startClient({
+    args: ['--output-dir', outputDir],
+  });
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: 'data:text/html,<html><title>Title</title><body>Hello, world!</body></html>',
+    },
+  })).toContainTextContent(`Navigate to data:text/html`);
+
+  await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: {},
+  });
+
+  expect(fs.existsSync(outputDir)).toBeTruthy();
+  expect([...fs.readdirSync(outputDir)]).toHaveLength(1);
+});
+
+
 test('browser_take_screenshot (outputDir)', async ({ startClient }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const client = await startClient({


### PR DESCRIPTION
## Description
This PR introduces a CLI option to specify the `outputDir`. Users can now dynamically set the output directory via command-line arguments, enhancing flexibility and ease of configuration.

## Motivation

The motivation behind this change is to dynamically set the `outputDir` from within the program, allowing screenshots to be organized into different folders for each execution.
With this modification, it becomes possible to directly specify the `outputDir` through the CLI without needing to generate a configuration file beforehand.


## Changes
- Added CLI parameter `--output-dir` to set the output directory.

## Usage Example

```bash
npx @playwright/mcp@latest --outputDir /custom/path
```