### PR TITLE
Introduce tool for generating reusable element locators

### DIFF
--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -289,7 +289,7 @@ const getLocator = defineTool({
           content: [{ type: 'text', text: await generateLocator(locator) }]
         };
       },
-      captureSnapshot: true,
+      captureSnapshot: false,
       waitForNetwork: false,
     };
   },

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -265,6 +265,36 @@ const screenshot = defineTool({
   }
 });
 
+const getLocator = defineTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_get_locator',
+    description: 'Get reusable locator for the element',
+    inputSchema: elementSchema,
+  },
+
+  handle: async (context, params) => {
+    const tab = context.currentTabOrDie();
+    const locator = tab.snapshotOrDie().refLocator(params.ref);
+
+    const code = [
+      `// Get reusable locator for ${params.element}`,
+      `await page.${await generateLocator(locator)};`
+    ];
+
+    return {
+      code,
+      action: async () => {
+        return {
+          content: [{ type: 'text', text: await generateLocator(locator) }]
+        };
+      },
+      captureSnapshot: true,
+      waitForNetwork: false,
+    };
+  },
+});
+
 export async function generateLocator(locator: playwright.Locator): Promise<string> {
   return (locator as any)._generateLocatorString();
 }
@@ -277,4 +307,5 @@ export default [
   type,
   selectOption,
   screenshot,
+  getLocator,
 ];


### PR DESCRIPTION
**Problem**:
Currently, element references obtained via browser_take_screenshot are transient. They become invalid after a page refresh or across different browser sessions, requiring the Agent to re-capture a screenshot to interact with the same logical element again.

**Solution**:
This PR introduces a new tool that generates a reusable locator for a given element.

**Benefits**:
Provides the Agent with a persistent way to identify elements across page loads and sessions.
Eliminates the need for repeated calls to browser_take_screenshot solely for element identification.
Improves the robustness and efficiency of agent interactions over time.