### PR TITLE
devops: publish Docker image to :latest as well

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,6 @@ jobs:
           file: ./Dockerfile # Adjust path if your Dockerfile is elsewhere
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: playwright.azurecr.io/public/playwright/mcp:${{ github.ref_name }}
+          tags: |
+            playwright.azurecr.io/public/playwright/mcp:${{ github.ref_name }}
+            playwright.azurecr.io/public/playwright/mcp:latest


### PR DESCRIPTION
We don't do that for normal Playwright because we expect the user to mount/add/copy their own Playwright folder and there the version has to match. In this case publishing to `:latest` seems fine since its a isolated product.
