### PR TITLE
chore: rename console to consoleMessages

### DIFF
--- a/src/tab.ts
+++ b/src/tab.ts
@@ -23,7 +23,7 @@ import type { Context } from './context.js';
 export class Tab {
   readonly context: Context;
   readonly page: playwright.Page;
-  private _console: playwright.ConsoleMessage[] = [];
+  private _consoleMessages: playwright.ConsoleMessage[] = [];
   private _requests: Map<playwright.Request, playwright.Response | null> = new Map();
   private _snapshot: PageSnapshot | undefined;
   private _onPageClose: (tab: Tab) => void;
@@ -32,7 +32,7 @@ export class Tab {
     this.context = context;
     this.page = page;
     this._onPageClose = onPageClose;
-    page.on('console', event => this._console.push(event));
+    page.on('console', event => this._consoleMessages.push(event));
     page.on('request', request => this._requests.set(request, null));
     page.on('response', response => this._requests.set(response.request(), response));
     page.on('framenavigated', frame => {
@@ -56,7 +56,7 @@ export class Tab {
   }
 
   private _clearCollectedArtifacts() {
-    this._console.length = 0;
+    this._consoleMessages.length = 0;
     this._requests.clear();
   }
 
@@ -81,8 +81,8 @@ export class Tab {
     return this._snapshot;
   }
 
-  console(): playwright.ConsoleMessage[] {
-    return this._console;
+  consoleMessages(): playwright.ConsoleMessage[] {
+    return this._consoleMessages;
   }
 
   requests(): Map<playwright.Request, playwright.Response | null> {

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -27,7 +27,7 @@ const console = defineTool({
     type: 'readOnly',
   },
   handle: async context => {
-    const messages = context.currentTabOrDie().console();
+    const messages = context.currentTabOrDie().consoleMessages();
     const log = messages.map(message => `[${message.type().toUpperCase()}] ${message.text()}`).join('\n');
     return {
       code: [`// <internal code to get console messages>`],


### PR DESCRIPTION
Motivation: `console` is a global object in Node.js and having a method like that confuses intellisense.