### PR TITLE
chore: unset skipLibCheck in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "skipLibCheck": true,
     "esModuleInterop": true,
     "moduleResolution": "nodenext",
     "strict": true,


### PR DESCRIPTION
Follow-up for https://github.com/microsoft/playwright-mcp/pull/385#discussion_r2081541865.

> `skipLibCheck`: Skip type checking all .d.ts files.
