### PR TITLE
docs: improve Linux configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,25 @@ npx @playwright/mcp@latest --config path/to/config.json
 
 ### Running on Linux
 
-When running headed browser on system w/o display or from worker processes of the IDEs,
-run the MCP server from environment with the DISPLAY and pass the `--port` flag to enable SSE transport.
+For systems with a display (most Linux desktop environments), set the DISPLAY environment variable:
+
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {
+        "DISPLAY": ":0"
+      }
+    }
+  }
+}
+```
+
+When running headed browser on system w/o display or from worker processes of the IDEs, run the MCP server from environment with the DISPLAY and pass the `--port` flag to enable SSE transport.
 
 ```bash
 npx @playwright/mcp@latest --port 8931


### PR DESCRIPTION
## Summary

This PR improves the Linux configuration section in the README to make it clearer and more straightforward for users. The current documentation is confusing about how to set up the DISPLAY environment variable on Linux systems.

## Changes

- Added a clear example for the most common Linux use case (desktop environments with display)
- Shows the simple configuration with DISPLAY=":0" that most Linux users need
- Reorganized the Linux section to show the simple case first
- Kept the existing SSE transport documentation for headless environments

## Motivation

The current documentation only mentions the DISPLAY environment in relation to "systems w/o display" which is confusing. Most Linux users running on desktop environments need to set DISPLAY=":0" in their configuration, which wasn't clearly documented.

This change makes it immediately clear how to configure playwright-mcp on:
1. Linux desktop environments (the common case)
2. Headless/CI environments (the special case)

## Testing

The proposed configuration has been tested and works correctly on Linux desktop environments.