### PR TITLE
fix: ensure browser_snapshot correctly handles undefined arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build": "tsc",
+    "build": "npx tsc",
     "lint": "npm run update-readme && eslint . && tsc --noEmit",
     "update-readme": "node utils/update-readme.js",
     "watch": "tsc --watch",

--- a/src/context.ts
+++ b/src/context.ts
@@ -125,7 +125,8 @@ export class Context {
 
   async run(tool: Tool, params: Record<string, unknown> | undefined) {
     // Tab management is done outside of the action() call.
-    const toolResult = await tool.handle(this, tool.schema.inputSchema.parse(params));
+    const parsedParams = tool.schema.inputSchema.parse(params === undefined ? {} : params);
+    const toolResult = await tool.handle(this, parsedParams);
     const { code, action, waitForNetwork, captureSnapshot, resultOverride } = toolResult;
     const racingAction = action ? () => this._raceAgainstModalDialogs(action) : undefined;
 


### PR DESCRIPTION
This commit resolves an issue where mcp7_browser_snapshot would fail
with an "invalid_type" error if called with no arguments. The root cause
was 'undefined' being passed to Zod's parse method for a schema
expecting an object. The fix ensures an empty object {} is provided
if parameters are undefined.

Additionally, the npm build script in package.json has been updated
from 'tsc' to 'npx tsc' to improve build reliability, particularly in
environments where TypeScript might not be globally installed or in the PATH.
