### PR TITLE
Fix import in README from createServer to createConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ docker build -t mcr.microsoft.com/playwright/mcp .
 ```js
 import http from 'http';
 
-import { createServer } from '@playwright/mcp';
+import { createConnection } from '@playwright/mcp';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
 http.createServer(async (req, res) => {


### PR DESCRIPTION
Probably, `createServer` is not from `@playwright/mcp`.