### PR TITLE
fix: Expand `browser_type` description with exact elements it can interact with

### DIFF
--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -147,7 +147,7 @@ const type = defineTool({
   schema: {
     name: 'browser_type',
     title: 'Type text',
-    description: 'Type text into editable element',
+    description: 'Type text into editable element such as <input>, <textarea> and [contenteditable] elements',
     inputSchema: typeSchema,
     type: 'destructive',
   },


### PR DESCRIPTION

Give AI a hint of what elements it can type into to reduce errors such as below:

```
 [{"type":"text","text":"Error: locator.fill: Error: Element is not an <input>, <textarea> or [contenteditable] element\nCall log:\n\u001b[2m  - waiting for locator('aria-ref=s23e585')\u001b[22m\n\u001b[2m    - locator resolved to <div role=\"combobox\" spellcheck=\"false\" aria-expanded=\"true\" aria-haspopup=\"listbox\" aria-owns=\"downshift-0-menu\" aria-labelledby=\"people-picker-label\" class=\"ui-box ac fl fk l fu en nu nv am nw nx ny ui-input ac fl fk l fu en nu ui-dropdown__searchinput__wrapper ui-dropdown__searchinput\">…</div>\u001b[22m\n\u001b[2m    - fill(\"testuser@example.com\")\u001b[22m\n\u001b[2m  - attempting fill action\u001b[22m\n\u001b[2m    - waiting for element to be visible, enabled and editable\u001b[22m\n"}]
```