### PR TITLE
chore: make library test run under older Node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ Playwright MCP server supports following arguments. They can be provided in the 
   --ignore-https-errors        ignore https errors
   --isolated                   keep the browser profile in memory, do not save
                                it to disk.
-  --no-image-responses         do not send image responses to the client.
+  --image-responses <mode>     whether to send image responses to the client.
+                               Can be "allow", "omit", or "auto". Defaults to
+                               "auto", which sends images if the client can
+                               display them.
   --no-sandbox                 disable the sandbox for all process types that
                                are normally sandboxed.
   --output-dir <path>          path to the directory for output files.

--- a/tests/library.spec.ts
+++ b/tests/library.spec.ts
@@ -20,8 +20,9 @@ import child_process from 'node:child_process';
 test('library can be used from CommonJS', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/456' } }, async ({}, testInfo) => {
   const file = testInfo.outputPath('main.cjs');
   await fs.writeFile(file, `
-    const playwrightMCP = require('@playwright/mcp');
-    playwrightMCP.createConnection().then(() => console.log('OK'));
+    import('@playwright/mcp')
+      .then(playwrightMCP => playwrightMCP.createConnection())
+      .then(() => console.log('OK'));
  `);
   expect(child_process.execSync(`node ${file}`, { encoding: 'utf-8' })).toContain('OK');
 });


### PR DESCRIPTION
This test only worked with `--experimental-require-module`, which is only enabled by default on recent Node versions. Changing the test to use a dynamic import tests the same regression, but works on older versions.