### PR TITLE
feat: add force click tool for snapshot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,17 +698,6 @@ X Y coordinate space, based on the provided screenshot.
 
 <!-- NOTE: This has been generated via update-readme.js -->
 
-- **browser_screen_click_force**
-  - Title: Force click
-  - Description: Force click at coordinates, bypassing any interactive checks
-  - Parameters:
-    - `element` (string): Human-readable element description used to obtain permission to interact with the element
-    - `x` (number): X coordinate
-    - `y` (number): Y coordinate
-  - Read-only: **false**
-
-<!-- NOTE: This has been generated via update-readme.js -->
-
 - **browser_screen_drag**
   - Title: Drag mouse
   - Description: Drag left mouse button

--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ X Y coordinate space, based on the provided screenshot.
 
 <!-- NOTE: This has been generated via update-readme.js -->
 
-- **browser_click_force**
-  - Title: Force click
-  - Description: Force click on element, bypassing any interactive checks
+- **browser_click_mouse_force**
+  - Title: Force click with mouse
+  - Description: Force click on element using direct mouse actions at element center
   - Parameters:
     - `element` (string): Human-readable element description used to obtain permission to interact with the element
     - `ref` (string): Exact target element reference from the page snapshot

--- a/README.md
+++ b/README.md
@@ -409,6 +409,16 @@ X Y coordinate space, based on the provided screenshot.
 
 <!-- NOTE: This has been generated via update-readme.js -->
 
+- **browser_click_force**
+  - Title: Force click
+  - Description: Force click on element, bypassing any interactive checks
+  - Parameters:
+    - `element` (string): Human-readable element description used to obtain permission to interact with the element
+    - `ref` (string): Exact target element reference from the page snapshot
+  - Read-only: **false**
+
+<!-- NOTE: This has been generated via update-readme.js -->
+
 - **browser_drag**
   - Title: Drag mouse
   - Description: Perform drag and drop between two elements
@@ -680,6 +690,17 @@ X Y coordinate space, based on the provided screenshot.
 - **browser_screen_click**
   - Title: Click
   - Description: Click left mouse button
+  - Parameters:
+    - `element` (string): Human-readable element description used to obtain permission to interact with the element
+    - `x` (number): X coordinate
+    - `y` (number): Y coordinate
+  - Read-only: **false**
+
+<!-- NOTE: This has been generated via update-readme.js -->
+
+- **browser_screen_click_force**
+  - Title: Force click
+  - Description: Force click at coordinates, bypassing any interactive checks
   - Parameters:
     - `element` (string): Human-readable element description used to obtain permission to interact with the element
     - `x` (number): X coordinate

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -96,7 +96,8 @@ const clickMouseForce = defineTool({
 
     const action = async () => {
       const box = await locator.boundingBox();
-      if (!box) throw new Error(`Element ${params.element} not visible or has no bounding box`);
+      if (!box)
+        throw new Error(`Element ${params.element} not visible or has no bounding box`);
       await tab.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
     };
 

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -74,6 +74,41 @@ const click = defineTool({
   },
 });
 
+const clickMouseForce = defineTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_click_mouse_force',
+    title: 'Force click with mouse',
+    description: 'Force click on element using direct mouse actions at element center',
+    inputSchema: elementSchema,
+    type: 'destructive',
+  },
+
+  handle: async (context, params) => {
+    const tab = context.currentTabOrDie();
+    const locator = tab.snapshotOrDie().refLocator(params);
+
+    const code = [
+      `// Get bounding box and force click ${params.element} with mouse`,
+      `const box = await page.${await generateLocator(locator)}.boundingBox();`,
+      `await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);`
+    ];
+
+    const action = async () => {
+      const box = await locator.boundingBox();
+      if (!box) throw new Error(`Element ${params.element} not visible or has no bounding box`);
+      await tab.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    };
+
+    return {
+      code,
+      action,
+      captureSnapshot: true,
+      waitForNetwork: true,
+    };
+  },
+});
+
 const drag = defineTool({
   capability: 'core',
   schema: {
@@ -219,6 +254,7 @@ const selectOption = defineTool({
 export default [
   snapshot,
   click,
+  clickMouseForce,
   drag,
   hover,
   type,

--- a/src/tools/vision.ts
+++ b/src/tools/vision.ts
@@ -121,37 +121,6 @@ const click = defineTool({
   },
 });
 
-const clickForce = defineTool({
-  capability: 'core',
-  schema: {
-    name: 'browser_screen_click_force',
-    title: 'Force click',
-    description: 'Force click at coordinates, bypassing any interactive checks',
-    inputSchema: elementSchema.extend({
-      x: z.number().describe('X coordinate'),
-      y: z.number().describe('Y coordinate'),
-    }),
-    type: 'destructive',
-  },
-
-  handle: async (context, params) => {
-    const tab = context.currentTabOrDie();
-    const code = [
-      `// Force click at coordinates (${params.x}, ${params.y})`,
-      `await page.locator('body').click({ position: { x: ${params.x}, y: ${params.y} }, force: true });`,
-    ];
-    const action = async () => {
-      await tab.page.locator('body').click({ position: { x: params.x, y: params.y }, force: true });
-    };
-    return {
-      code,
-      action,
-      captureSnapshot: false,
-      waitForNetwork: true,
-    };
-  },
-});
-
 const drag = defineTool({
   capability: 'core',
   schema: {
@@ -239,7 +208,6 @@ export default [
   screenshot,
   moveMouse,
   click,
-  clickForce,
   drag,
   type,
 ];

--- a/src/tools/vision.ts
+++ b/src/tools/vision.ts
@@ -121,6 +121,37 @@ const click = defineTool({
   },
 });
 
+const clickForce = defineTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_screen_click_force',
+    title: 'Force click',
+    description: 'Force click at coordinates, bypassing any interactive checks',
+    inputSchema: elementSchema.extend({
+      x: z.number().describe('X coordinate'),
+      y: z.number().describe('Y coordinate'),
+    }),
+    type: 'destructive',
+  },
+
+  handle: async (context, params) => {
+    const tab = context.currentTabOrDie();
+    const code = [
+      `// Force click at coordinates (${params.x}, ${params.y})`,
+      `await page.locator('body').click({ position: { x: ${params.x}, y: ${params.y} }, force: true });`,
+    ];
+    const action = async () => {
+      await tab.page.locator('body').click({ position: { x: params.x, y: params.y }, force: true });
+    };
+    return {
+      code,
+      action,
+      captureSnapshot: false,
+      waitForNetwork: true,
+    };
+  },
+});
+
 const drag = defineTool({
   capability: 'core',
   schema: {
@@ -208,6 +239,7 @@ export default [
   screenshot,
   moveMouse,
   click,
+  clickForce,
   drag,
   type,
 ];


### PR DESCRIPTION
This PR solves the issue https://github.com/microsoft/playwright-mcp/issues/474
This "force click" method bypasses actionability checks for stubborn elements.

- Add browser_click_mouse_force for snapshot mode using direct mouse actions
