### PR TITLE
POC: setup CORs headers

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -95,6 +95,16 @@ export function startHttpTransport(server: Server, port: number, hostname: strin
   const sseSessions = new Map<string, SSEServerTransport>();
   const streamableSessions = new Map<string, StreamableHTTPServerTransport>();
   const httpServer = http.createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', 'https://claude.ai');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, sentry-trace, baggage');
+
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 200;
+      res.end();
+      return;
+    }
+
     const url = new URL(`http://localhost${req.url}`);
     if (url.pathname.startsWith('/mcp'))
       await handleStreamable(server, req, res, streamableSessions);


### PR DESCRIPTION
This PR can't be merged as is, but hopefully it is illustrative.  Currently, it's
not possible to directly talk to playwright-mcp server over SSE directly from
claude.ai in the browser with claude-mcp extension because there aren't
relaxed enough CORS headers to allow the browser extension to query the MCP
server.  It would definitely be helpful if this is configurable.  This PR
empirically works to unblock me for this case, but clearly it cannot be merged
as is.
