### PR TITLE
Refactor: Remove Playwright code echoing from responses

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -164,11 +164,13 @@ export class Context {
     }
 
     const result: string[] = [];
+    /*
     result.push(`- Ran Playwright code:
 \`\`\`js
 ${code.join('\n')}
 \`\`\`
 `);
+    */
 
     if (this.modalStates().length) {
       result.push(...this.modalStatesMarkdown());


### PR DESCRIPTION
This change modifies the `Context.run` method in `src/context.ts` to prevent the echoing of executed Playwright code snippets in the textual response.

The Playwright code block (`- Ran Playwright code: ...`) has been commented out from the response assembly logic. This directly addresses the issue of verbose outputs and reduces token context usage by making the responses more concise.

The actual execution of actions remains unaffected. Conceptual verification and code review confirm that this change should not negatively impact functionality. Direct end-to-end testing of the server output was not performed due to limitations in the execution environment for this specific type of change.

This aligns with the goal of making interactions more streamlined.