### PR TITLE
chore: fix Connection type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,13 +16,11 @@
  */
 
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { Config } from './config';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { Config } from './config.js';
 import type { BrowserContext } from 'playwright';
 
 export type Connection = {
   server: Server;
-  connect(transport: Transport): Promise<void>;
   close(): Promise<void>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Connection, createConnection as createConnectionImpl } from './connection.js';
+import { createConnection as createConnectionImpl } from './connection.js';
+import type { Connection } from '../index.js';
 import { resolveConfig } from './config.js';
 import { contextFactory } from './browserContextFactory.js';
 


### PR DESCRIPTION
The external `Connection` type regressed in https://github.com/microsoft/playwright-mcp/pull/490/files#diff-a6be0583428e46844273df76939f02077073da3075716fc57d291a5f2463eaf5, where the `connect()` function was removed but not from the types. I've changed the code so we import from there, similar to how we do it for `config.d.ts`, so this shouldn't happen again.