### PR TITLE
docs(readme): fix connection method call in programmatic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ http.createServer(async (req, res) => {
   // Creates a headless Playwright MCP server with SSE transport
   const connection = await createConnection({ browser: { launchOptions: { headless: true } } });
   const transport = new SSEServerTransport('/messages', res);
-  await connection.connect(transport);
+  await connection.sever.connect(transport);
 
   // ...
 });


### PR DESCRIPTION
The `createConnection` function returns an instance of the `Connection` class, which doesn't have a `connect` method. Updated the documentation to use `connection.server.connect(transport)` instead of `connection.connect(transport)` to match the actual implementation.

Related to #529