### PR TITLE
chore: add json schema file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playwright-report/
 
 .idea
 .DS_Store
+config.json

--- a/README.md
+++ b/README.md
@@ -253,6 +253,23 @@ using the `--config` command line option:
 npx @playwright/mcp@latest --config path/to/config.json
 ```
 
+```json
+// path/to/config.json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/playwright-mcp/main/config.schema.json",
+  "browser": {
+    "browserName": "chromium",
+    "launchOptions": {
+      "channel": "msedge"
+    },
+    "contextOptions": {
+      "timezoneId": "Europe/Berlin",
+      "locale": "de-DE"
+    }
+  }
+}
+```
+
 <details>
 <summary>Configuration file schema</summary>
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -18,6 +18,32 @@ import type * as playwright from 'playwright';
 
 export type ToolCapability = 'core' | 'tabs' | 'pdf' | 'history' | 'wait' | 'files' | 'install' | 'testing';
 
+type LaunchOptions = Omit<
+  playwright.LaunchOptions,
+    'handleSIGHUP'
+  | 'handleSIGINT'
+  | 'handleSIGTERM'
+  | 'logger'
+>;
+
+type ClientCertificate = Omit<
+  NonNullable<playwright.BrowserContextOptions['clientCertificates']>[number],
+    'cert' | 'key' | 'pfx'
+>;
+
+interface RecordHar extends Omit<NonNullable<playwright.BrowserContextOptions['recordHar']>, 'urlFilter'> {
+  urlFilter?: string;
+}
+
+interface BrowserContextOptions extends Omit<
+  playwright.BrowserContextOptions,
+    'logger'
+  | 'clientCertificates'
+> {
+  clientCertificates?: ClientCertificate[];
+  recordHar?: RecordHar;
+}
+
 export type Config = {
   /**
    * The browser to use.
@@ -50,14 +76,14 @@ export type Config = {
      *
      * This is useful for settings options like `channel`, `headless`, `executablePath`, etc.
      */
-    launchOptions?: playwright.LaunchOptions;
+    launchOptions?: LaunchOptions;
 
     /**
      * Context options for the browser context.
      *
      * This is useful for settings options like `viewport`.
      */
-    contextOptions?: playwright.BrowserContextOptions;
+    contextOptions?: BrowserContextOptions;
 
     /**
      * Chrome DevTools Protocol endpoint to connect to an existing browser instance in case of Chromium family browsers.

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,692 @@
+{
+  "type": "object",
+  "properties": {
+    "browser": {
+      "description": "The browser to use.",
+      "type": "object",
+      "properties": {
+        "browserAgent": {
+          "description": "Use browser agent (experimental).",
+          "type": "string"
+        },
+        "browserName": {
+          "description": "The type of browser to use.",
+          "enum": [
+            "chromium",
+            "firefox",
+            "webkit"
+          ],
+          "type": "string"
+        },
+        "isolated": {
+          "description": "Keep the browser profile in memory, do not save it to disk.",
+          "type": "boolean"
+        },
+        "userDataDir": {
+          "description": "Path to a user data directory for browser profile persistence.\nTemporary directory is created by default.",
+          "type": "string"
+        },
+        "launchOptions": {
+          "$ref": "#/definitions/LaunchOptions",
+          "description": "Launch options passed to"
+        },
+        "contextOptions": {
+          "$ref": "#/definitions/BrowserContextOptions",
+          "description": "Context options for the browser context.\n\nThis is useful for settings options like `viewport`."
+        },
+        "cdpEndpoint": {
+          "description": "Chrome DevTools Protocol endpoint to connect to an existing browser instance in case of Chromium family browsers.",
+          "type": "string"
+        },
+        "remoteEndpoint": {
+          "description": "Remote endpoint to connect to an existing Playwright server.",
+          "type": "string"
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "description": "The port to listen on for SSE or MCP transport.",
+          "type": "number"
+        },
+        "host": {
+          "description": "The host to bind the server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.",
+          "type": "string"
+        }
+      }
+    },
+    "capabilities": {
+      "description": "List of enabled tool capabilities. Possible values:\n  - 'core': Core browser automation features.\n  - 'tabs': Tab management features.\n  - 'pdf': PDF generation and manipulation.\n  - 'history': Browser history access.\n  - 'wait': Wait and timing utilities.\n  - 'files': File upload/download support.\n  - 'install': Browser installation utilities.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ToolCapability"
+      }
+    },
+    "vision": {
+      "description": "Run server that uses screenshots (Aria snapshots are used by default).",
+      "type": "boolean"
+    },
+    "saveTrace": {
+      "description": "Whether to save the Playwright trace of the session into the output directory.",
+      "type": "boolean"
+    },
+    "outputDir": {
+      "description": "The directory to save output files.",
+      "type": "string"
+    },
+    "network": {
+      "type": "object",
+      "properties": {
+        "allowedOrigins": {
+          "description": "List of origins to allow the browser to request. Default is to allow all. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blockedOrigins": {
+          "description": "List of origins to block the browser to request. Origins matching both `allowedOrigins` and `blockedOrigins` will be blocked.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "imageResponses": {
+      "description": "Whether to send image responses to the client. Can be \"allow\", \"omit\", or \"auto\". Defaults to \"auto\", which sends images if the client can display them.",
+      "enum": [
+        "allow",
+        "auto",
+        "omit"
+      ],
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "LaunchOptions": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "description": "Browser distribution channel.\n\nUse \"chromium\" to [opt in to new headless mode](https://playwright.dev/docs/browsers#chromium-new-headless-mode).\n\nUse \"chrome\", \"chrome-beta\", \"chrome-dev\", \"chrome-canary\", \"msedge\", \"msedge-beta\", \"msedge-dev\", or\n\"msedge-canary\" to use branded [Google Chrome and Microsoft Edge](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge).",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`\nto disable timeout.",
+          "type": "number"
+        },
+        "proxy": {
+          "description": "Network proxy settings.",
+          "type": "object",
+          "properties": {
+            "server": {
+              "description": "Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or\n`socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.",
+              "type": "string"
+            },
+            "bypass": {
+              "description": "Optional comma-separated domains to bypass proxy, for example `\".com, chromium.org, .domain.com\"`.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Optional username to use if HTTP proxy requires authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Optional password to use if HTTP proxy requires authentication.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "server"
+          ]
+        },
+        "args": {
+          "description": "**NOTE** Use custom browser args at your own risk, as some of them may break Playwright functionality.\n\nAdditional arguments to pass to the browser instance. The list of Chromium flags can be found\n[here](https://peter.sh/experiments/chromium-command-line-switches/).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chromiumSandbox": {
+          "description": "Enable Chromium sandboxing. Defaults to `false`.",
+          "type": "boolean"
+        },
+        "devtools": {
+          "description": "**Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the\n[`headless`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-headless) option will be\nset `false`.",
+          "type": "boolean"
+        },
+        "downloadsPath": {
+          "description": "If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and\nis deleted when browser is closed. In either case, the downloads are deleted when the browser context they were\ncreated in is closed.",
+          "type": "string"
+        },
+        "env": {
+          "description": "Specify environment variables that will be visible to the browser. Defaults to `process.env`.",
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
+        "executablePath": {
+          "description": "Path to a browser executable to run instead of the bundled one. If\n[`executablePath`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-executable-path) is\na relative path, then it is resolved relative to the current working directory. Note that Playwright only works\nwith the bundled Chromium, Firefox or WebKit, use at your own risk.",
+          "type": "string"
+        },
+        "firefoxUserPrefs": {
+          "description": "Firefox user preferences. Learn more about the Firefox user preferences at\n[`about:config`](https://support.mozilla.org/en-US/kb/about-config-editor-firefox).\n\nYou can also provide a path to a custom [`policies.json` file](https://mozilla.github.io/policy-templates/) via\n`PLAYWRIGHT_FIREFOX_POLICIES_JSON` environment variable.",
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
+        "headless": {
+          "description": "Whether to run browser in headless mode. More details for\n[Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and\n[Firefox](https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/). Defaults to `true` unless the\n[`devtools`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-devtools) option is\n`true`.",
+          "type": "boolean"
+        },
+        "ignoreDefaultArgs": {
+          "description": "If `true`, Playwright does not pass its own configurations args and only uses the ones from\n[`args`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-args). If an array is given,\nthen filters out the given default arguments. Dangerous option; use with care. Defaults to `false`.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "slowMo": {
+          "description": "Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going\non.",
+          "type": "number"
+        },
+        "tracesDir": {
+          "description": "If specified, traces are saved into this directory.",
+          "type": "string"
+        }
+      }
+    },
+    "BrowserContextOptions": {
+      "type": "object",
+      "properties": {
+        "clientCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClientCertificate"
+          }
+        },
+        "recordHar": {
+          "$ref": "#/definitions/RecordHar",
+          "description": "Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file.\nIf not specified, the HAR is not recorded. Make sure to await\n[browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) for\nthe HAR to be saved."
+        },
+        "geolocation": {
+          "$ref": "#/definitions/Geolocation"
+        },
+        "colorScheme": {
+          "description": "Emulates [prefers-colors-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)\nmedia feature, supported values are `'light'` and `'dark'`. See\n[page.emulateMedia([options])](https://playwright.dev/docs/api/class-page#page-emulate-media) for more details.\nPassing `null` resets emulation to system defaults. Defaults to `'light'`.",
+          "enum": [
+            "dark",
+            "light",
+            "no-preference"
+          ],
+          "type": "string"
+        },
+        "screen": {
+          "description": "Emulates consistent window screen size available inside web page via `window.screen`. Is only used when the\n[`viewport`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-viewport) is set.",
+          "type": "object",
+          "properties": {
+            "width": {
+              "description": "page width in pixels.",
+              "type": "number"
+            },
+            "height": {
+              "description": "page height in pixels.",
+              "type": "number"
+            }
+          },
+          "required": [
+            "height",
+            "width"
+          ]
+        },
+        "offline": {
+          "description": "Whether to emulate network being offline. Defaults to `false`. Learn more about\n[network emulation](https://playwright.dev/docs/emulation#offline).",
+          "type": "boolean"
+        },
+        "proxy": {
+          "description": "Network proxy settings to use with this context. Defaults to none.",
+          "type": "object",
+          "properties": {
+            "server": {
+              "description": "Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or\n`socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.",
+              "type": "string"
+            },
+            "bypass": {
+              "description": "Optional comma-separated domains to bypass proxy, for example `\".com, chromium.org, .domain.com\"`.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Optional username to use if HTTP proxy requires authentication.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Optional password to use if HTTP proxy requires authentication.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "server"
+          ]
+        },
+        "acceptDownloads": {
+          "description": "Whether to automatically download all the attachments. Defaults to `true` where all the downloads are accepted.",
+          "type": "boolean"
+        },
+        "baseURL": {
+          "description": "When using [page.goto(url[, options])](https://playwright.dev/docs/api/class-page#page-goto),\n[page.route(url, handler[, options])](https://playwright.dev/docs/api/class-page#page-route),\n[page.waitForURL(url[, options])](https://playwright.dev/docs/api/class-page#page-wait-for-url),\n[page.waitForRequest(urlOrPredicate[, options])](https://playwright.dev/docs/api/class-page#page-wait-for-request),\nor\n[page.waitForResponse(urlOrPredicate[, options])](https://playwright.dev/docs/api/class-page#page-wait-for-response)\nit takes the base URL in consideration by using the\n[`URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor for building the corresponding URL.\nUnset by default. Examples:\n- baseURL: `http://localhost:3000` and navigating to `/bar.html` results in `http://localhost:3000/bar.html`\n- baseURL: `http://localhost:3000/foo/` and navigating to `./bar.html` results in\n  `http://localhost:3000/foo/bar.html`\n- baseURL: `http://localhost:3000/foo` (without trailing slash) and navigating to `./bar.html` results in\n  `http://localhost:3000/bar.html`",
+          "type": "string"
+        },
+        "bypassCSP": {
+          "description": "Toggles bypassing page's Content-Security-Policy. Defaults to `false`.",
+          "type": "boolean"
+        },
+        "contrast": {
+          "description": "Emulates `'prefers-contrast'` media feature, supported values are `'no-preference'`, `'more'`. See\n[page.emulateMedia([options])](https://playwright.dev/docs/api/class-page#page-emulate-media) for more details.\nPassing `null` resets emulation to system defaults. Defaults to `'no-preference'`.",
+          "enum": [
+            "more",
+            "no-preference"
+          ],
+          "type": "string"
+        },
+        "deviceScaleFactor": {
+          "description": "Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about\n[emulating devices with device scale factor](https://playwright.dev/docs/emulation#devices).",
+          "type": "number"
+        },
+        "extraHTTPHeaders": {
+          "description": "An object containing additional HTTP headers to be sent with every request. Defaults to none.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "forcedColors": {
+          "description": "Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See\n[page.emulateMedia([options])](https://playwright.dev/docs/api/class-page#page-emulate-media) for more details.\nPassing `null` resets emulation to system defaults. Defaults to `'none'`.",
+          "enum": [
+            "active",
+            "none"
+          ],
+          "type": "string"
+        },
+        "hasTouch": {
+          "description": "Specifies if viewport supports touch events. Defaults to false. Learn more about\n[mobile emulation](https://playwright.dev/docs/emulation#devices).",
+          "type": "boolean"
+        },
+        "httpCredentials": {
+          "$ref": "#/definitions/HTTPCredentials",
+          "description": "Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). If no\norigin is specified, the username and password are sent to any servers upon unauthorized responses."
+        },
+        "ignoreHTTPSErrors": {
+          "description": "Whether to ignore HTTPS errors when sending network requests. Defaults to `false`.",
+          "type": "boolean"
+        },
+        "isMobile": {
+          "description": "Whether the `meta viewport` tag is taken into account and touch events are enabled. isMobile is a part of device,\nso you don't actually need to set it manually. Defaults to `false` and is not supported in Firefox. Learn more\nabout [mobile emulation](https://playwright.dev/docs/emulation#ismobile).",
+          "type": "boolean"
+        },
+        "javaScriptEnabled": {
+          "description": "Whether or not to enable JavaScript in the context. Defaults to `true`. Learn more about\n[disabling JavaScript](https://playwright.dev/docs/emulation#javascript-enabled).",
+          "type": "boolean"
+        },
+        "locale": {
+          "description": "Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value,\n`Accept-Language` request header value as well as number and date formatting rules. Defaults to the system default\nlocale. Learn more about emulation in our [emulation guide](https://playwright.dev/docs/emulation#locale--timezone).",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "A list of permissions to grant to all pages in this context. See\n[browserContext.grantPermissions(permissions[, options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions)\nfor more details. Defaults to none.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recordVideo": {
+          "description": "Enables video recording for all pages into `recordVideo.dir` directory. If not specified videos are not recorded.\nMake sure to await\n[browserContext.close([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-close) for\nvideos to be saved.",
+          "type": "object",
+          "properties": {
+            "dir": {
+              "description": "Path to the directory to put videos into.",
+              "type": "string"
+            },
+            "size": {
+              "description": "Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to\nfit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of\neach page will be scaled down if necessary to fit the specified size.",
+              "type": "object",
+              "properties": {
+                "width": {
+                  "description": "Video frame width.",
+                  "type": "number"
+                },
+                "height": {
+                  "description": "Video frame height.",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "height",
+                "width"
+              ]
+            }
+          },
+          "required": [
+            "dir"
+          ]
+        },
+        "reducedMotion": {
+          "description": "Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See\n[page.emulateMedia([options])](https://playwright.dev/docs/api/class-page#page-emulate-media) for more details.\nPassing `null` resets emulation to system defaults. Defaults to `'no-preference'`.",
+          "enum": [
+            "no-preference",
+            "reduce"
+          ],
+          "type": "string"
+        },
+        "serviceWorkers": {
+          "description": "Whether to allow sites to register Service workers. Defaults to `'allow'`.\n- `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be\n  registered.\n- `'block'`: Playwright will block all registration of Service Workers.",
+          "enum": [
+            "allow",
+            "block"
+          ],
+          "type": "string"
+        },
+        "storageState": {
+          "description": "Learn more about [storage state and auth](https://playwright.dev/docs/auth).\n\nPopulates context with given storage state. This option can be used to initialize context with logged-in\ninformation obtained via\n[browserContext.storageState([options])](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state).",
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "cookies": {
+                  "description": "Cookies to set for context",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "domain": {
+                        "description": "Domain and path are required. For the cookie to apply to all subdomains as well, prefix domain with a dot, like\nthis: \".example.com\"",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Domain and path are required",
+                        "type": "string"
+                      },
+                      "expires": {
+                        "description": "Unix time in seconds.",
+                        "type": "number"
+                      },
+                      "httpOnly": {
+                        "type": "boolean"
+                      },
+                      "secure": {
+                        "type": "boolean"
+                      },
+                      "sameSite": {
+                        "description": "sameSite flag",
+                        "enum": [
+                          "Lax",
+                          "None",
+                          "Strict"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "domain",
+                      "expires",
+                      "httpOnly",
+                      "name",
+                      "path",
+                      "sameSite",
+                      "secure",
+                      "value"
+                    ]
+                  }
+                },
+                "origins": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "origin": {
+                        "type": "string"
+                      },
+                      "localStorage": {
+                        "description": "localStorage to set for context",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ]
+                        }
+                      }
+                    },
+                    "required": [
+                      "localStorage",
+                      "origin"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "cookies",
+                "origins"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "strictSelectors": {
+          "description": "If set to true, enables strict selectors mode for this context. In the strict selectors mode all operations on\nselectors that imply single target DOM element will throw when more than one element matches the selector. This\noption does not affect any Locator APIs (Locators are always strict). Defaults to `false`. See\n[Locator](https://playwright.dev/docs/api/class-locator) to learn more about the strict mode.",
+          "type": "boolean"
+        },
+        "timezoneId": {
+          "description": "Changes the timezone of the context. See\n[ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1)\nfor a list of supported timezone IDs. Defaults to the system timezone.",
+          "type": "string"
+        },
+        "userAgent": {
+          "description": "Specific user agent to use in this context.",
+          "type": "string"
+        },
+        "videoSize": {
+          "type": "object",
+          "properties": {
+            "width": {
+              "description": "Video frame width.",
+              "type": "number"
+            },
+            "height": {
+              "description": "Video frame height.",
+              "type": "number"
+            }
+          },
+          "required": [
+            "height",
+            "width"
+          ]
+        },
+        "videosPath": {
+          "type": "string"
+        },
+        "viewport": {
+          "$ref": "#/definitions/ViewportSize",
+          "description": "Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `null` to disable the consistent\nviewport emulation. Learn more about [viewport emulation](https://playwright.dev/docs/emulation#viewport).\n\n**NOTE** The `null` value opts out from the default presets, makes viewport depend on the host window size defined\nby the operating system. It makes the execution of the tests non-deterministic."
+        }
+      }
+    },
+    "ClientCertificate": {
+      "type": "object",
+      "properties": {
+        "origin": {
+          "description": "Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.",
+          "type": "string"
+        },
+        "certPath": {
+          "description": "Path to the file with the certificate in PEM format.",
+          "type": "string"
+        },
+        "keyPath": {
+          "description": "Path to the file with the private key in PEM format.",
+          "type": "string"
+        },
+        "pfxPath": {
+          "description": "Path to the PFX or PKCS12 encoded private key and certificate chain.",
+          "type": "string"
+        },
+        "passphrase": {
+          "description": "Passphrase for the private key (PEM or PFX).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "origin"
+      ]
+    },
+    "RecordHar": {
+      "type": "object",
+      "properties": {
+        "urlFilter": {
+          "type": "string"
+        },
+        "content": {
+          "description": "Optional setting to control resource content management. If `omit` is specified, content is not persisted. If\n`attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is\nspecified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output\nfiles and to `embed` for all other file extensions.",
+          "enum": [
+            "attach",
+            "embed",
+            "omit"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "description": "Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by\ndefault.",
+          "type": "string"
+        },
+        "omitContent": {
+          "description": "Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use\n`content` policy instead.",
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,\ncookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.",
+          "enum": [
+            "full",
+            "minimal"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "Geolocation": {
+      "type": "object",
+      "properties": {
+        "latitude": {
+          "description": "Latitude between -90 and 90.",
+          "type": "number"
+        },
+        "longitude": {
+          "description": "Longitude between -180 and 180.",
+          "type": "number"
+        },
+        "accuracy": {
+          "description": "Non-negative accuracy value. Defaults to `0`.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude"
+      ]
+    },
+    "HTTPCredentials": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "origin": {
+          "description": "Restrain sending http credentials on specific origin (scheme://host:port).",
+          "type": "string"
+        },
+        "send": {
+          "description": "This option only applies to the requests sent from corresponding\n[APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext) and does not affect requests sent from\nthe browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each\nAPI request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with\n`WWW-Authenticate` header is received. Defaults to `'unauthorized'`.",
+          "enum": [
+            "always",
+            "unauthorized"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "password",
+        "username"
+      ]
+    },
+    "ViewportSize": {
+      "type": "object",
+      "properties": {
+        "width": {
+          "description": "page width in pixels.",
+          "type": "number"
+        },
+        "height": {
+          "description": "page height in pixels.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "height",
+        "width"
+      ]
+    },
+    "ToolCapability": {
+      "enum": [
+        "core",
+        "files",
+        "history",
+        "install",
+        "pdf",
+        "tabs",
+        "testing",
+        "wait"
+      ],
+      "type": "string"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,10 +35,24 @@
         "eslint": "^9.19.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-notice": "^1.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.2",
+        "typescript-json-schema": "^0.65.1"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -232,6 +246,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
@@ -358,6 +400,34 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chrome": {
       "version": "0.0.315",
@@ -707,6 +777,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -724,6 +807,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -739,6 +832,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1028,6 +1128,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1115,6 +1230,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1253,6 +1375,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1284,6 +1416,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1436,6 +1575,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2027,6 +2176,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2078,6 +2234,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2133,6 +2299,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2354,6 +2542,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2543,6 +2743,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2881,6 +3091,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -3240,6 +3457,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3248,6 +3472,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3472,6 +3706,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3627,6 +3871,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -3842,6 +4096,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -3899,6 +4168,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -3983,6 +4265,50 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -4117,6 +4443,57 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-json-schema": {
+      "version": "0.65.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.65.1.tgz",
+      "integrity": "sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^18.11.9",
+        "glob": "^7.1.7",
+        "path-equal": "^1.2.5",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "~5.5.0",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "typescript-json-schema": "bin/typescript-json-schema"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/@types/node": {
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -4161,6 +4538,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4285,6 +4669,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4310,6 +4712,55 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",
-    "lint": "npm run update-readme && eslint . && tsc --noEmit",
+    "lint": "npm run update-readme && npm run update-schema && eslint . && tsc --noEmit",
     "update-readme": "node utils/update-readme.js",
+    "update-schema": "node utils/update-config-schema-json.js",
     "watch": "tsc --watch",
     "test": "playwright test",
     "ctest": "playwright test --project=chrome",
@@ -60,7 +61,8 @@
     "eslint": "^9.19.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-notice": "^1.0.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "typescript-json-schema": "^0.65.1"
   },
   "bin": {
     "mcp-server-playwright": "cli.js"

--- a/utils/update-config-schema-json.js
+++ b/utils/update-config-schema-json.js
@@ -1,0 +1,20 @@
+import * as TJS from "typescript-json-schema";
+import path from "node:path";
+import fs from "node:fs";
+
+const root = path.resolve(import.meta.dirname, '..');
+
+const program = TJS.getProgramFromFiles([path.resolve(root, 'config.d.ts')]);
+
+const schema = TJS.generateSchema(
+    program,
+    "Config",
+    {
+        required: true,
+    }
+);
+
+fs.writeFileSync(
+    path.resolve(root, 'config.schema.json'),
+    JSON.stringify(schema, null, 2)
+)


### PR DESCRIPTION
We're seeing a multiple issues (https://github.com/microsoft/playwright-mcp/issues/571, https://github.com/microsoft/playwright-mcp/issues/546) about discovery for `config.json` properties. This PR gives the config file Intellisense, by generating a json-schema file and recommending it in our README.