### PR TITLE
Add a fullPage param to the playwright_screen_capture tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,8 @@ X Y coordinate space, based on the provided screenshot.
 - **browser_screen_capture**
   - Title: Take a screenshot
   - Description: Take a screenshot of the current page
-  - Parameters: None
+  - Parameters:
+    - `fullPage` (boolean, optional): Whether the whole page should be screenshotted, or only the current viewport
   - Read-only: **true**
 
 <!-- NOTE: This has been generated via update-readme.js -->

--- a/src/tools/vision.ts
+++ b/src/tools/vision.ts
@@ -29,13 +29,23 @@ const screenshot = defineTool({
     name: 'browser_screen_capture',
     title: 'Take a screenshot',
     description: 'Take a screenshot of the current page',
-    inputSchema: z.object({}),
+    inputSchema: z.object({
+      fullPage: z.boolean().optional().describe('Whether the whole page should be screenshotted, or only the current viewport'),
+    }),
     type: 'readOnly',
   },
 
-  handle: async context => {
+  handle: async (context, params) => {
     const tab = await context.ensureTab();
-    const options = { type: 'jpeg' as 'jpeg', quality: 50, scale: 'css' as 'css' };
+    const options = {
+      type: 'jpeg' as 'jpeg',
+      quality: 50,
+      scale: 'css' as 'css',
+    };
+
+    if (params.fullPage) {
+      Object.assign(options, { fullPage: true });
+    }
 
     const code = [
       `// Take a screenshot of the current page`,


### PR DESCRIPTION
the use case that I am exploring right now is for site builder agent that could get an instant full page feedback on a site it is building.
i think it is an useful already existing feature of playwright that should be useful for its MCP as well.