### PR TITLE
chore: support custom testIdAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ npx @playwright/mcp@latest --config path/to/config.json
 
     // Remote Playwright server endpoint
     remoteEndpoint?: string;
+
+    // testIdAttribute to use. Defaults to "data-testid"
+    testIdAttribute?: string;
   },
 
   // Server configuration

--- a/config.d.ts
+++ b/config.d.ts
@@ -68,6 +68,11 @@ export type Config = {
      * Remote endpoint to connect to an existing Playwright server.
      */
     remoteEndpoint?: string;
+
+    /**
+     * The attribute to use for test IDs. Defaults to "data-testid".
+     */
+    testIdAttribute?: string;
   },
 
   server?: {

--- a/src/context.ts
+++ b/src/context.ts
@@ -346,6 +346,8 @@ ${code.join('\n')}
         sources: false,
       });
     }
+    if (this.config.browser?.testIdAttribute)
+      playwright.selectors.setTestIdAttribute(this.config.browser.testIdAttribute);
     return result;
   }
 }

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -70,6 +70,79 @@ await page.getByRole('button', { name: 'Submit' }).click();
 `);
 });
 
+test('browser_click with testid', async ({ client, server }) => {
+  server.setContent('/', `
+    <title>Title</title>
+    <button data-testid="submit-btn">Submit</button>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'Submit button',
+      ref: 'e2',
+    },
+  })).toHaveTextContent(`
+- Ran Playwright code:
+\`\`\`js
+// Click Submit button
+await page.getByTestId('submit-btn').click();
+\`\`\`
+
+- Page URL: ${server.PREFIX}
+- Page Title: Title
+- Page Snapshot
+\`\`\`yaml
+- button "Submit" [ref=e2]
+\`\`\`
+`);
+});
+
+test('browser_click with custom testid', async ({ startClient, server }) => {
+  const { client } = await startClient({
+    config: {
+      browser: {
+        testIdAttribute: 'data-custom-testid',
+      }
+    }
+  });
+  server.setContent('/', `
+    <title>Title</title>
+    <button data-custom-testid="submit-btn">Submit</button>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'Submit button',
+      ref: 'e2',
+    },
+  })).toHaveTextContent(`
+- Ran Playwright code:
+\`\`\`js
+// Click Submit button
+await page.getByTestId('submit-btn').click();
+\`\`\`
+
+- Page URL: ${server.PREFIX}
+- Page Title: Title
+- Page Snapshot
+\`\`\`yaml
+- button "Submit" [ref=e2]
+\`\`\`
+`);
+});
+
 test('browser_select_option', async ({ client, server }) => {
   server.setContent('/', `
     <title>Title</title>


### PR DESCRIPTION
This will allow users to set a custom testId which is helpful for projects relying on a different one. Especially with testing use-cases where generation from existing code/text/logic is happening.