### PR TITLE
feat(screenshot): add fullPage parameter to browser_take_screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ X Y coordinate space, based on the provided screenshot.
   - Title: Take a screenshot
   - Description: Take a screenshot of the current page. You can't perform actions based on the screenshot, use browser_snapshot for actions.
   - Parameters:
+    - `fullPage` (boolean, optional): Whether the whole page should be screenshotted, or only the current viewport
     - `raw` (boolean, optional): Whether to return without compression (in PNG format). Default is false, which returns a JPEG image.
     - `filename` (string, optional): File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.
     - `element` (string, optional): Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -24,6 +24,7 @@ import { generateLocator } from './utils.js';
 import type * as playwright from 'playwright';
 
 const screenshotSchema = z.object({
+  fullPage: z.boolean().optional().describe('Whether the whole page should be screenshotted, or only the current viewport'),
   raw: z.boolean().optional().describe('Whether to return without compression (in PNG format). Default is false, which returns a JPEG image.'),
   filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
@@ -51,6 +52,9 @@ const screenshot = defineTool({
     const fileType = params.raw ? 'png' : 'jpeg';
     const fileName = await outputFile(context.config, params.filename ?? `page-${new Date().toISOString()}.${fileType}`);
     const options: playwright.PageScreenshotOptions = { type: fileType, quality: fileType === 'png' ? undefined : 50, scale: 'css', path: fileName };
+    if (params.fullPage)
+      options.fullPage = true;
+
     const isElementScreenshot = params.element && params.ref;
 
     const code = [


### PR DESCRIPTION
## Summary
- Add fullPage boolean parameter to browser_take_screenshot tool
- Enables capturing full page screenshots beyond current viewport
- Maintains backward compatibility with existing usage

## Changes
- Updated screenshot tool schema to include fullPage parameter
- Added proper parameter handling in screenshot logic
- Updated documentation via automated script

## Testing
- Verified parameter correctly passed to Playwright screenshot options
- Confirmed backward compatibility maintained
- Documentation automatically updated and validated