### PR TITLE
docs: Update README about imageResponses option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,10 @@ npx @playwright/mcp@latest --config path/to/config.json
   };
  
   /**
-   * Do not send image responses to the client.
+   * Whether to send image responses to the client. Can be "allow", "omit", or "auto". 
+   * Defaults to "auto", images are omitted for Cursor clients and sent for all other clients.
    */
-  noImageResponses?: boolean;
+  imageResponses?: 'allow' | 'omit' | 'auto';
 }
 ```
 </details>


### PR DESCRIPTION
## Summary
- Removed `noImageResponses` option in README configuration schema
- Add to use correct `imageResponses` option with proper type and description


## Changes
- Aligned README documentation with actual `config.d.ts` interface

## Context
The README documentation contained an outdated `noImageResponses` boolean option. The correct option is `imageResponses` with three possible values as defined in [`config.d.ts:127`](https://github.com/microsoft/playwright-mcp/blob/main/config.d.ts#L127).


