### PR TITLE
chore: remove image reply special case in cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,7 @@ Playwright MCP server supports following arguments. They can be provided in the 
   --isolated                   keep the browser profile in memory, do not save
                                it to disk.
   --image-responses <mode>     whether to send image responses to the client.
-                               Can be "allow", "omit", or "auto". Defaults to
-                               "auto", which sends images if the client can
-                               display them.
+                               Can be "allow" or "omit", Defaults to "allow".
   --no-sandbox                 disable the sandbox for all process types that
                                are normally sandboxed.
   --output-dir <path>          path to the directory for output files.
@@ -347,10 +345,10 @@ npx @playwright/mcp@latest --config path/to/config.json
   };
  
   /**
-   * Whether to send image responses to the client. Can be "allow", "omit", or "auto". 
-   * Defaults to "auto", images are omitted for Cursor clients and sent for all other clients.
+   * Whether to send image responses to the client. Can be "allow" or "omit". 
+   * Defaults to "allow".
    */
-  imageResponses?: 'allow' | 'omit' | 'auto';
+  imageResponses?: 'allow' | 'omit';
 }
 ```
 </details>

--- a/config.d.ts
+++ b/config.d.ts
@@ -115,5 +115,5 @@ export type Config = {
   /**
    * Whether to send image responses to the client. Can be "allow", "omit", or "auto". Defaults to "auto", which sends images if the client can display them.
    */
-  imageResponses?: 'allow' | 'omit' | 'auto';
+  imageResponses?: 'allow' | 'omit';
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export type CLIOptions = {
   host?: string;
   ignoreHttpsErrors?: boolean;
   isolated?: boolean;
-  imageResponses?: 'allow' | 'omit' | 'auto';
+  imageResponses?: 'allow' | 'omit';
   sandbox: boolean;
   outputDir?: string;
   port?: number;

--- a/src/context.ts
+++ b/src/context.ts
@@ -52,11 +52,9 @@ export class Context {
   }
 
   clientSupportsImages(): boolean {
-    if (this.config.imageResponses === 'allow')
-      return true;
     if (this.config.imageResponses === 'omit')
       return false;
-    return !this.clientVersion?.name.includes('cursor');
+    return true;
   }
 
   modalStates(): ModalState[] {

--- a/src/program.ts
+++ b/src/program.ts
@@ -40,7 +40,7 @@ program
     .option('--host <host>', 'host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.')
     .option('--ignore-https-errors', 'ignore https errors')
     .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
-    .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow", "omit", or "auto". Defaults to "auto", which sends images if the client can display them.')
+    .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".')
     .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
     .option('--output-dir <path>', 'path to the directory for output files.')
     .option('--port <port>', 'port to listen on for SSE transport.')

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -201,32 +201,3 @@ test('browser_take_screenshot (imageResponses=omit)', async ({ startClient, serv
     ],
   });
 });
-
-test('browser_take_screenshot (cursor)', async ({ startClient, server }, testInfo) => {
-  const outputDir = testInfo.outputPath('output');
-
-  const { client } = await startClient({
-    clientName: 'cursor:vscode',
-    config: { outputDir },
-  });
-
-  expect(await client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  })).toContainTextContent(`Navigate to http://localhost`);
-
-  await client.callTool({
-    name: 'browser_take_screenshot',
-  });
-
-  expect(await client.callTool({
-    name: 'browser_take_screenshot',
-  })).toEqual({
-    content: [
-      {
-        text: expect.stringContaining(`Screenshot viewport and save it as`),
-        type: 'text',
-      },
-    ],
-  });
-});


### PR DESCRIPTION
Latest Cursor will suggest the right thing (to switch model)
<img width="633" height="111" alt="Screenshot from 2025-07-16 16-34-40" src="https://github.com/user-attachments/assets/7e3f14ed-4e2f-4dd8-920a-cc8f148982e4" />
