### PR TITLE
feat(docker): allow exposing remote access via port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ FROM base
 ARG PLAYWRIGHT_BROWSERS_PATH
 ARG USERNAME=node
 ENV NODE_ENV=production
+ENV REMOTE_HTTP=
+
+# Used when REMOTE_HTTP is set
+EXPOSE 8931
 
 # Set the correct ownership for the runtime user on production `node_modules`
 RUN chown -R ${USERNAME}:${USERNAME} node_modules
@@ -66,4 +70,4 @@ COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
 # Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${PORT:+--port $PORT}"]
+ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--port 8931}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
 # Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--host 0.0.0.0 --port 8931}"]
+ENTRYPOINT ["sh", "-c", "PLAYWRIGHT_DOCKER=1 node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--host 0.0.0.0 --port 8931}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
 # Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--port 8931}"]
+ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--remote 0.0.0.0 --port 8931}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM base
 ARG PLAYWRIGHT_BROWSERS_PATH
 ARG USERNAME=node
 ENV NODE_ENV=production
-ENV REMOTE_HTTP=
+ENV REMOTE_HTTP=false
 
 # Used when REMOTE_HTTP is set
 EXPOSE 8931
@@ -70,4 +70,4 @@ COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
 # Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--remote 0.0.0.0 --port 8931}"]
+ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--host 0.0.0.0 --port 8931}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
 # Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["node", "cli.js", "--headless", "--browser", "chromium", "--no-sandbox"]
+ENTRYPOINT ["sh", "-c", "node cli.js --headless --browser chromium --no-sandbox ${PORT:+--port $PORT}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ RUN chown -R ${USERNAME}:${USERNAME} node_modules
 USER ${USERNAME}
 
 COPY --from=browser --chown=${USERNAME}:${USERNAME} ${PLAYWRIGHT_BROWSERS_PATH} ${PLAYWRIGHT_BROWSERS_PATH}
-COPY --chown=${USERNAME}:${USERNAME} cli.js package.json ./
+COPY --chown=${USERNAME}:${USERNAME} cli.js package.json entrypoint.sh ./
 COPY --from=builder --chown=${USERNAME}:${USERNAME} /app/lib /app/lib
 
-# Run in headless and only with chromium (other browsers need more dependencies not included in this image)
-ENTRYPOINT ["sh", "-c", "PLAYWRIGHT_DOCKER=1 node cli.js --headless --browser chromium --no-sandbox ${REMOTE_HTTP:+--host 0.0.0.0 --port 8931}"]
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -320,12 +320,37 @@ And then in MCP client config, set the `url` to the SSE endpoint:
 
 **NOTE:** The Docker implementation only supports headless chromium at the moment.
 
+For running Docker on your local machine, add it to your MCP config as normal:
+
 ```js
 {
   "mcpServers": {
     "playwright": {
       "command": "docker",
       "args": ["run", "-i", "--rm", "--init", "--pull=always", "mcr.microsoft.com/playwright/mcp"]
+    }
+  }
+}
+```
+
+You can also set up Docker to run Playwright MCP remotely, for example using Docker Compose:
+
+```yml
+playwright-mcp:
+  image: mcr.microsoft.com/playwright/mcp
+  ports:
+    - "8931:8931"
+  environment:
+    REMOTE_HTTP: 1
+```
+
+This allows you to connect to this container at port 8931 on your Docker host from your remote machine:
+
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "url": "http://[DOCKER_HOST_IP]:8931/sse"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ For running Docker on your local machine, add it to your MCP config as normal:
 }
 ```
 
-You can also set up Docker to run Playwright MCP remotely, for example using Docker Compose:
+You can also set up Docker to run Playwright MCP remotely by setting the `REMOTE_HTTP` environment variable, for example using Docker Compose:
 
 ```yml
 playwright-mcp:

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ playwright-mcp:
   ports:
     - "8931:8931"
   environment:
-    REMOTE_HTTP: 1
+    REMOTE_HTTP: true
 ```
 
 This allows you to connect to this container at port 8931 on your Docker host from your remote machine:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Mark as running in Docker
+export PLAYWRIGHT_DOCKER=1
+
+# Run in headless and only with chromium (other browsers need more dependencies not included in this image)
+BASE_ARGS="--headless --browser chromium --no-sandbox"
+
+if [ "$REMOTE_HTTP" = "true" ] || [ "$REMOTE_HTTP" = "1" ]; then
+    exec node cli.js $BASE_ARGS --host 0.0.0.0 --port 8931
+else
+    exec node cli.js $BASE_ARGS
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # Mark as running in Docker
 export PLAYWRIGHT_DOCKER=1
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -143,6 +143,8 @@ export function httpAddressToString(address: string | AddressInfo | null): strin
     return address;
   const resolvedPort = address.port;
   let resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
+  if (process.env.PLAYWRIGHT_DOCKER)
+    resolvedHost = '[DOCKER_HOST_IP]';
   if (resolvedHost === '0.0.0.0' || resolvedHost === '[::]')
     resolvedHost = 'localhost';
   return `http://${resolvedHost}:${resolvedPort}`;


### PR DESCRIPTION
More advanced use cases of tools like MCP will require multiple Docker containers, particularly on hosts other than the user's machine. Expose the HTTP transport through a `REMOTE_HTTP` envvar and allow the user to connect to the server through the Docker firewall.

Docker logs this to the console as startup:
```
Listening on http://[DOCKER_HOST_IP]:8931
Put this in your client config:
{
  "mcpServers": {
    "playwright": {
      "url": "http://[DOCKER_HOST_IP]:8931/sse"
    }
  }
}
If your client supports streamable HTTP, you can use the /mcp endpoint instead.
```