### PR TITLE
add cdp options for connect via cdp

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Playwright MCP server supports following arguments. They can be provided in the 
   --caps <caps>                comma-separated list of additional capabilities
                                to enable, possible values: vision, pdf.
   --cdp-endpoint <endpoint>    CDP endpoint to connect to.
+  --cdp-headers <headers>      CDP headers to use when connecting to CDP endpoint. 
+                               Format: JSON string or key:value,key2:value2
   --config <path>              path to the configuration file.
   --device <device>            device to emulate, for example: "iPhone 15"
   --executable-path <path>     path to the browser executable.
@@ -217,6 +219,24 @@ state [here](https://playwright.dev/docs/auth).
 }
 ```
 
+### CDP Headers
+
+When connecting to a CDP endpoint, you can specify headers to be sent with the CDP connection. This is useful for authentication or other custom headers required by your CDP endpoint.
+
+```bash
+# Using JSON format
+npx @playwright/mcp@latest --cdp-endpoint="http://localhost:9222" --cdp-headers='{"Authorization":"Bearer token123","X-Custom-Header":"CustomValue"}'
+
+# Using key:value format
+npx @playwright/mcp@latest --cdp-endpoint="http://localhost:9222" --cdp-headers='Authorization:Bearer token123,X-Custom-Header:CustomValue'
+```
+
+When using Docker:
+
+```bash
+docker run -i --rm --init mcr.microsoft.com/playwright/mcp --cdp-endpoint="http://host.docker.internal:9222" --cdp-headers='{"Authorization":"Bearer token123"}'
+```
+
 ### Configuration file
 
 The Playwright MCP server can be configured using a JSON configuration file. You can specify the configuration file
@@ -260,6 +280,13 @@ npx @playwright/mcp@latest --config path/to/config.json
 
     // CDP endpoint for connecting to existing browser
     cdpEndpoint?: string;
+    
+    // Options for CDP connection
+    connectOptions?: {
+      headers?: Record<string, string>; // Headers to send with CDP connection
+      timeout?: number;                 // Connection timeout in milliseconds
+      slowMo?: number;                  // Slow down operations by the specified amount of milliseconds
+    };
 
     // Remote Playwright server endpoint
     remoteEndpoint?: string;

--- a/config.d.ts
+++ b/config.d.ts
@@ -63,6 +63,12 @@ export type Config = {
      * Remote endpoint to connect to an existing Playwright server.
      */
     remoteEndpoint?: string;
+
+    /**
+     * Options to pass to connectOverCDP method.
+     * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp
+     */
+    connectOptions?: Record<string, any>;
   },
 
   server?: {

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -121,7 +121,7 @@ class CdpContextFactory extends BaseContextFactory {
   }
 
   protected override async _doObtainBrowser(): Promise<playwright.Browser> {
-    return playwright.chromium.connectOverCDP(this.browserConfig.cdpEndpoint!);
+    return playwright.chromium.connectOverCDP(this.browserConfig.cdpEndpoint!, this.browserConfig.connectOptions);
   }
 
   protected override async _doCreateContext(browser: playwright.Browser): Promise<playwright.BrowserContext> {
@@ -191,7 +191,7 @@ class PersistentContextFactory implements BrowserContextFactory {
   private async _closeBrowserContext(browserContext: playwright.BrowserContext, userDataDir: string) {
     testDebug('close browser context (persistent)');
     testDebug('release user data dir', userDataDir);
-    await browserContext.close().catch(() => {});
+    await browserContext.close().catch(() => { });
     this._userDataDirs.delete(userDataDir);
     testDebug('close browser context complete (persistent)');
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export type CLIOptions = {
   browser?: string;
   caps?: string[];
   cdpEndpoint?: string;
+  cdpHeaders?: string;
   config?: string;
   device?: string;
   executablePath?: string;
@@ -76,6 +77,7 @@ export type FullConfig = Config & {
     browserName: 'chromium' | 'firefox' | 'webkit';
     launchOptions: NonNullable<BrowserUserConfig['launchOptions']>;
     contextOptions: NonNullable<BrowserUserConfig['contextOptions']>;
+    connectOptions?: Record<string, any>;
   },
   network: NonNullable<Config['network']>,
   outputDir: string;
@@ -179,6 +181,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
       launchOptions,
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
+      connectOptions: (cliOptions as any).connectOptions || (cliOptions.cdpHeaders ? { headers: parseHeaders(cliOptions.cdpHeaders) } : undefined),
     },
     server: {
       port: cliOptions.port,
@@ -205,7 +208,16 @@ function configFromEnv(): Config {
   options.browser = envToString(process.env.PLAYWRIGHT_MCP_BROWSER);
   options.caps = commaSeparatedList(process.env.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(process.env.PLAYWRIGHT_MCP_CDP_ENDPOINT);
+  options.cdpHeaders = envToString(process.env.PLAYWRIGHT_MCP_CDP_HEADERS);
   options.config = envToString(process.env.PLAYWRIGHT_MCP_CONFIG);
+  const connectOptionsEnv = envToString(process.env.PLAYWRIGHT_MCP_CONNECT_OPTIONS);
+  if (connectOptionsEnv) {
+    try {
+      (options as any).connectOptions = JSON.parse(connectOptionsEnv);
+    } catch (e) {
+      throw new Error(`Failed to parse PLAYWRIGHT_MCP_CONNECT_OPTIONS as JSON: ${e}`);
+    }
+  }
   options.device = envToString(process.env.PLAYWRIGHT_MCP_DEVICE);
   options.executablePath = envToString(process.env.PLAYWRIGHT_MCP_EXECUTABLE_PATH);
   options.headless = envToBoolean(process.env.PLAYWRIGHT_MCP_HEADLESS);
@@ -313,4 +325,22 @@ function envToBoolean(value: string | undefined): boolean | undefined {
 
 function envToString(value: string | undefined): string | undefined {
   return value ? value.trim() : undefined;
+}
+
+function parseHeaders(headersString: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  try {
+    // First try to parse as JSON
+    return JSON.parse(headersString);
+  } catch (e) {
+    // If not valid JSON, try to parse as key:value pairs
+    const pairs = headersString.split(',');
+    for (const pair of pairs) {
+      const [key, value] = pair.split(':').map(s => s.trim());
+      if (key && value) {
+        headers[key] = value;
+      }
+    }
+    return headers;
+  }
 }

--- a/src/program.ts
+++ b/src/program.ts
@@ -33,6 +33,7 @@ program
     .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
     .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf.', commaSeparatedList)
     .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
+    .option('--cdp-headers <headers>', 'CDP headers to use when connecting to CDP endpoint. Format: JSON string or key:value,key2:value2')
     .option('--config <path>', 'path to the configuration file.')
     .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
     .option('--executable-path <path>', 'path to the browser executable.')


### PR DESCRIPTION
# Add support for CDP headers in connectOverCDP

## Description
This PR adds support for specifying headers when connecting to a CDP endpoint. This is useful for authentication or other custom headers required by CDP endpoints.

## Features
- Added a new `--cdp-headers` command-line parameter that accepts headers in either JSON format or key:value pairs
- Added support for reading CDP headers from the `PLAYWRIGHT_MCP_CDP_HEADERS` environment variable
- Updated the configuration schema to include `connectOptions` with headers for CDP connections
- Added documentation and examples in the README

## Implementation
- Added a new parameter to the `connectOverCDP` method in `CdpContextFactory` class
- Added a `parseHeaders` helper function to parse headers from string formats
- Updated the CLI options and environment variable handling
- Added documentation in the README with examples

## Example Usage
```bash
# Using JSON format
npx @playwright/mcp@latest --cdp-endpoint="http://localhost:9222" --cdp-headers='{"Authorization":"Bearer token123","X-Custom-Header":"CustomValue"}'

# Using key:value format
npx @playwright/mcp@latest --cdp-endpoint="http://localhost:9222" --cdp-headers='Authorization:Bearer token123,X-Custom-Header:CustomValue'
