### PR TITLE
Creating Ignore https errors as an mcp tool

### DIFF
--- a/examples/ignore-https-errors.md
+++ b/examples/ignore-https-errors.md
@@ -1,0 +1,60 @@
+# Ignore HTTPS Errors Example
+
+This example demonstrates how to use the `browser_ignore_https_errors` tool to configure the browser to ignore HTTPS certificate errors.
+
+## Use Case
+
+When testing applications that use self-signed certificates or have certificate issues during development, you may need to bypass HTTPS certificate validation.
+
+## Basic Usage
+
+```typescript
+// Enable ignoring HTTPS errors
+await mcp.callTool({
+  name: 'browser_ignore_https_errors',
+  arguments: {
+    ignore: true
+  }
+});
+
+// Now you can navigate to sites with certificate issues
+await mcp.callTool({
+  name: 'browser_navigate',
+  arguments: {
+    url: 'https://self-signed-certificate-site.com'
+  }
+});
+
+// Later, if you want to re-enable certificate validation
+await mcp.callTool({
+  name: 'browser_ignore_https_errors',
+  arguments: {
+    ignore: false
+  }
+});
+```
+
+## Configuration via CLI
+
+You can also set this option when starting the MCP server:
+
+```bash
+npx @playwright/mcp@latest --ignore-https-errors
+```
+
+## Important Notes
+
+- This setting recreates the browser context with the new configuration
+- All existing tabs will be closed when the context is recreated
+- For security reasons, only use this in development/testing environments
+- The setting persists for the current session until explicitly changed
+
+## Equivalent Playwright Code
+
+This tool is equivalent to creating a browser context with:
+
+```javascript
+const context = await browser.newContext({
+  ignoreHTTPSErrors: true
+});
+``` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "playwright": "1.55.0-alpha-1752701791000",
         "playwright-core": "1.55.0-alpha-1752701791000",
         "ws": "^8.18.1",
+        "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.4"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "playwright": "1.55.0-alpha-1752701791000",
     "playwright-core": "1.55.0-alpha-1752701791000",
     "ws": "^8.18.1",
+    "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.4"
   },
   "devDependencies": {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,6 +16,7 @@
 
 import common from './tools/common.js';
 import console from './tools/console.js';
+import context from './tools/context.js';
 import dialogs from './tools/dialogs.js';
 import evaluate from './tools/evaluate.js';
 import files from './tools/files.js';
@@ -35,6 +36,7 @@ import type { Tool } from './tools/tool.js';
 export const allTools: Tool<any>[] = [
   ...common,
   ...console,
+  ...context,
   ...dialogs,
   ...evaluate,
   ...files,

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -35,7 +35,7 @@ const ignoreHttpsErrors = defineTool({
     context.config.browser.contextOptions.ignoreHTTPSErrors = params.ignore;
     
     // Force recreation of the browser context by closing the current one
-    await context.close();
+    //await context.close();
     
     // Ensure a new tab is created with the updated context
     const tab = await context.ensureTab();

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+import { defineTool } from './tool.js';
+
+const ignoreHttpsErrors = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_ignore_https_errors',
+    title: 'Ignore HTTPS errors',
+    description: 'Configure the browser to ignore HTTPS certificate errors. This will recreate the browser context with the new setting.',
+    inputSchema: z.object({
+      ignore: z.boolean().describe('Whether to ignore HTTPS certificate errors. Set to true to ignore HTTPS errors.'),
+    }),
+    type: 'destructive',
+  },
+
+  handle: async (context, params, response) => {
+    // Update the context options in the config
+    context.config.browser.contextOptions.ignoreHTTPSErrors = params.ignore;
+    
+    // Force recreation of the browser context by closing the current one
+    await context.close();
+    
+    // Ensure a new tab is created with the updated context
+    const tab = await context.ensureTab();
+    
+    response.setIncludeSnapshot();
+    response.addCode(`// Configure browser to ${params.ignore ? 'ignore' : 'validate'} HTTPS certificate errors`);
+    response.addCode(`// Browser context recreated with ignoreHTTPSErrors: ${params.ignore}`);
+    response.addResult(`Browser context recreated with HTTPS error handling ${params.ignore ? 'disabled' : 'enabled'}`);
+  },
+});
+
+export default [
+  ignoreHttpsErrors,
+]; 

--- a/tests/ignore-https-errors.spec.ts
+++ b/tests/ignore-https-errors.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures.js';
+
+test('browser_ignore_https_errors tool enables HTTPS error ignoring', async ({ client, httpsServer }) => {
+  // Set up a self-signed HTTPS server that would normally cause certificate errors
+  httpsServer.setRoute('/test', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><body><h1>HTTPS Test Page</h1></body></html>');
+  });
+
+  // First try to navigate without ignoring HTTPS errors - this should fail
+  await client.tools.browser_navigate({ url: httpsServer.url('/test') });
+  
+  // Now enable HTTPS error ignoring
+  const ignoreResult = await client.tools.browser_ignore_https_errors({ ignore: true });
+  expect(ignoreResult).toContain('Browser context recreated with HTTPS error handling disabled');
+
+  // Now try to navigate again - this should succeed
+  const navigateResult = await client.tools.browser_navigate({ url: httpsServer.url('/test') });
+  expect(navigateResult).toContain('HTTPS Test Page');
+
+  // Verify we can disable HTTPS error ignoring again
+  const restoreResult = await client.tools.browser_ignore_https_errors({ ignore: false });
+  expect(restoreResult).toContain('Browser context recreated with HTTPS error handling enabled');
+});
+
+test('browser_ignore_https_errors tool parameter validation', async ({ client }) => {
+  // Test with valid boolean value
+  const result = await client.tools.browser_ignore_https_errors({ ignore: true });
+  expect(result).toContain('Browser context recreated');
+  
+  // Test parameter is required
+  await expect(client.tools.browser_ignore_https_errors({} as any)).rejects.toThrow();
+}); 


### PR DESCRIPTION
Hii, we want to launch the chrome browser with these setting by cursor or claude desktop , we are using mcp for 1st level sanity of projects. I don't want my team to go on changing the configuration for testing on different environments . 

We want to use this feature like :----  **Start a fresh Chrome browser in non-headless mode with HTTPS certificate errors ignored.**   