### PR TITLE
fix: Don't mask server hostname

### DIFF
--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -37,8 +37,6 @@ export function httpAddressToString(address: string | net.AddressInfo | null): s
   if (typeof address === 'string')
     return address;
   const resolvedPort = address.port;
-  let resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
-  if (resolvedHost === '0.0.0.0' || resolvedHost === '[::]')
-    resolvedHost = 'localhost';
+  const resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
   return `http://${resolvedHost}:${resolvedPort}`;
 }


### PR DESCRIPTION
PR #751 introduced invalid hostnames which are sent to the output, which creates issues with troubleshooting.

This cleans up the incorrect informational messages.

Closes https://github.com/microsoft/playwright-mcp/issues/790