### PR TITLE
chore(package): add dependence `zod`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "playwright": "1.55.0-alpha-1752701791000",
         "playwright-core": "1.55.0-alpha-1752701791000",
         "ws": "^8.18.1",
+        "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.4"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "playwright": "1.55.0-alpha-1752701791000",
     "playwright-core": "1.55.0-alpha-1752701791000",
     "ws": "^8.18.1",
+    "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.4"
   },
   "devDependencies": {


### PR DESCRIPTION
When I install dependencies via pnpm the zod is missing.