### PR TITLE
feat: economize on output tokens

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -96,7 +96,20 @@ export class Response {
   serialize(): { content: (TextContent | ImageContent)[], isError?: boolean } {
     const response: string[] = [];
 
-    // Start with command result.
+    // Add snapshot if provided.
+    if (this._tabSnapshot?.modalStates.length) {
+      response.push(...renderModalStates(this._context, this._tabSnapshot.modalStates));
+      response.push('');
+    } else if (this._tabSnapshot) {
+      response.push(renderTabSnapshot(this._tabSnapshot));
+      response.push('');
+    }
+
+    // List browser tabs.
+    if (this._includeSnapshot || this._includeTabs)
+      response.push(...renderTabsMarkdown(this._context.tabs(), this._includeTabs));
+
+    // Command result.
     if (this._result.length) {
       response.push('### Result');
       response.push(this._result.join('\n'));
@@ -109,19 +122,6 @@ export class Response {
 \`\`\`js
 ${this._code.join('\n')}
 \`\`\``);
-      response.push('');
-    }
-
-    // List browser tabs.
-    if (this._includeSnapshot || this._includeTabs)
-      response.push(...renderTabsMarkdown(this._context.tabs(), this._includeTabs));
-
-    // Add snapshot if provided.
-    if (this._tabSnapshot?.modalStates.length) {
-      response.push(...renderModalStates(this._context, this._tabSnapshot.modalStates));
-      response.push('');
-    } else if (this._tabSnapshot) {
-      response.push(renderTabSnapshot(this._tabSnapshot));
       response.push('');
     }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -143,6 +143,8 @@ ${this._code.join('\n')}
 function renderTabSnapshot(tabSnapshot: TabSnapshot): string {
   const lines: string[] = [];
 
+  // Put first the elements that are less likely to change for the same web page,
+  // to exploit Context Caching whenever it is available.
   lines.push(`### Page state`);
   lines.push(`- Page URL: ${tabSnapshot.url}`);
   lines.push(`- Page Title: ${tabSnapshot.title}`);


### PR DESCRIPTION
Here are a few optimizations to reduce the number of output token generated:

- Remove the `[cursor=pointer]` attribute that is added on every clickable element. On a news site I tested (`ilpost.it`) this amounted for ~12% of the tokens of the ARIA snapshot.
- When rendering the output of `browser_snapshot`, output the ARIA snapshot before the console messages and other info. By keeping large content at the beginning of the prompt, we are able to exploit [implicit context caching](https://ai.google.dev/gemini-api/docs/caching) on Gemini, potentially saving on costs if the bulk of the snapshot does not change among multiple invocations.
- Omit all the console logs with severity level < `WARNING`, and deduplicate them.

This should at least mitigate the issues of #395.