### PR TITLE
feat: Add CDP headers support for authenticated connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Playwright MCP server supports following arguments. They can be provided in the 
   --caps <caps>                comma-separated list of additional capabilities
                                to enable, possible values: vision, pdf.
   --cdp-endpoint <endpoint>    CDP endpoint to connect to.
+  --cdp-headers <headers>      JSON string of headers to send with CDP
+                               connection, e.g. '{"Authorization": "Bearer
+                               token"}'
   --config <path>              path to the configuration file.
   --device <device>            device to emulate, for example: "iPhone 15"
   --executable-path <path>     path to the browser executable.

--- a/config.d.ts
+++ b/config.d.ts
@@ -60,6 +60,12 @@ export type Config = {
     cdpEndpoint?: string;
 
     /**
+     * Additional HTTP headers to be sent with CDP connect request.
+     * Only used when cdpEndpoint is specified.
+     */
+    cdpHeaders?: Record<string, string>;
+
+    /**
      * Remote endpoint to connect to an existing Playwright server.
      */
     remoteEndpoint?: string;

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -128,7 +128,11 @@ class CdpContextFactory extends BaseContextFactory {
   }
 
   protected override async _doObtainBrowser(): Promise<playwright.Browser> {
-    return playwright.chromium.connectOverCDP(this.config.browser.cdpEndpoint!);
+    const options: any = {};
+    if (this.config.browser.cdpHeaders)
+      options.headers = this.config.browser.cdpHeaders;
+
+    return playwright.chromium.connectOverCDP(this.config.browser.cdpEndpoint!, options);
   }
 
   protected override async _doCreateContext(browser: playwright.Browser): Promise<playwright.BrowserContext> {

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -128,7 +128,7 @@ class CdpContextFactory extends BaseContextFactory {
   }
 
   protected override async _doObtainBrowser(): Promise<playwright.Browser> {
-    const options: any = {};
+    const options: playwright.ConnectOverCDPOptions = {};
     if (this.config.browser.cdpHeaders)
       options.headers = this.config.browser.cdpHeaders;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -302,19 +302,20 @@ export function semicolonSeparatedList(value: string | undefined): string[] | un
 export function parseJsonObject(value: string | undefined): Record<string, string> | undefined {
   if (!value)
     return undefined;
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(value);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
-      throw new InvalidArgumentError('Expected JSON object');
-
-    return parsed;
+    parsed = JSON.parse(value);
   } catch (error) {
-    if (error instanceof InvalidArgumentError)
-      throw error;
-
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new InvalidArgumentError(`Invalid JSON format: ${errorMessage}`);
   }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new InvalidArgumentError('Expected JSON object');
+  }
+
+  return parsed as Record<string, string>;
 }
 
 export function commaSeparatedList(value: string | undefined): string[] | undefined {

--- a/src/program.ts
+++ b/src/program.ts
@@ -16,7 +16,7 @@
 
 import { program, Option } from 'commander';
 import * as mcpServer from './mcp/server.js';
-import { commaSeparatedList, resolveCLIConfig, semicolonSeparatedList } from './config.js';
+import { commaSeparatedList, parseJsonObject, resolveCLIConfig, semicolonSeparatedList } from './config.js';
 import { packageJSON } from './utils/package.js';
 import { Context } from './context.js';
 import { contextFactory } from './browserContextFactory.js';
@@ -37,6 +37,7 @@ program
     .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
     .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf.', commaSeparatedList)
     .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
+    .option('--cdp-headers <headers>', 'JSON string of headers to send with CDP connection, e.g. \'{"Authorization": "Bearer token"}\'', parseJsonObject)
     .option('--config <path>', 'path to the configuration file.')
     .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
     .option('--executable-path <path>', 'path to the browser executable.')


### PR DESCRIPTION
## Summary
Adds support for passing authentication headers when connecting to CDP endpoints, enabling connections to authenticated browser instances like AWS Bedrock AgentCore Browser.

## Background
Modern AI agent platforms like AWS Bedrock AgentCore provide managed browser instances that require authenticated CDP connections. Currently, playwright-mcp cannot pass authentication headers when connecting to CDP endpoints, preventing integration with these enterprise-grade services.

Amazon Bedrock AgentCore Browser service provides managed, secure, cloud-based browser instances that enable AI agents to interact with websites at scale for tasks like form completion and web navigation. These browser instances require authenticated CDP connections with proper headers for security and access control.

## Changes
- **Configuration**: Add `cdpHeaders` option to browser configuration type definitions
- **CLI Support**: Add `--cdp-headers` option with JSON parsing and validation
- **Environment Variables**: Support `PLAYWRIGHT_MCP_CDP_HEADERS` for configuration
- **Core Implementation**: Update `CdpContextFactory` to pass headers to Playwright's `connectOverCDP`
- **Error Handling**: Robust JSON parsing with clear error messages
- **Testing**: Add test cases for headers functionality and invalid JSON handling
- **Documentation**: Update README with usage examples and environment variable support

## Usage Examples

### CLI Usage
bash
```bash
npx @playwright/mcp --cdp-endpoint=ws://localhost:9222 --cdp-headers='{
"Authorization": "Bearer token"}'
```

### Environment Variable
bash
```bash
export PLAYWRIGHT_MCP_CDP_HEADERS='{"Authorization": "Bearer token"}'
npx @playwright/mcp --cdp-endpoint=ws://localhost:9222
```

### Configuration File
json
```json
{
 "browser": {
   "cdpEndpoint": "ws://localhost:9222",
   "cdpHeaders": {
     "Authorization": "Bearer token",
     "X-Custom-Header": "value"
   }
 }
}
```

## Compatibility
- **Backward Compatible**: All new options are optional
- **No Breaking Changes**: Existing CDP connections work unchanged
- **Progressive Enhancement**: New functionality only activated when headers are provided

## Use Cases
This feature enables integration with:
- **AWS Bedrock AgentCore Browser**: Enterprise AI agent browser automation
- **Authenticated CDP endpoints**: Any browser instance requiring authentication
- **Multi-tenant systems**: User-scoped browser access with authentication

## References
- [Amazon Bedrock AgentCore Browser Tool Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/browser-tool.html)
- [Amazon Bedrock AgentCore Overview](https://aws.amazon.com/bedrock/agentcore/)
- [Playwright connectOverCDP API](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp)
