### PR TITLE
Update README from mcpServers to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, install the Playwright MCP server with your client.
 
 ```js
 {
-  "mcpServers": {
+  "servers": {
     "playwright": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
Because the section in VS Code is titled `servers`, this allows for a copy/paste into an empty `mcp.json` file