### PR TITLE
docs: add explicit project-based installation for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,25 @@ Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, u
 <details>
 <summary>Gemini CLI</summary>
 
+Global setup:
 Follow the MCP install [guide](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#configure-the-mcp-server-in-settingsjson), use the standard config above.
+
+Project-enabled setup:
+- create a .gemini folder
+- create a settings.json file inside the folder with the standard setup:
+
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}
+```
 
 </details>
 


### PR DESCRIPTION
## Summary
Added explicit instructions for project-based installation of Playwright MCP with Gemini CLI, providing users with a clearer and more organized setup option.

## What changed
- Added a new "Project-enabled setup" section alongside the existing global setup
- Included step-by-step instructions for creating `.gemini` folder and `settings.json`
- Provided complete JSON configuration example for the Playwright MCP server

## Why this change
The previous documentation only showed global installation, which can be confusing for users who prefer project-specific configurations. This change:
- Gives users flexibility to choose between global or project-based setup
- Improves organization by keeping configurations isolated per project
- Makes the setup process clearer with explicit folder and file creation steps

## Type of change
- [x] Documentation improvement

## Testing
- Not applicable