### PR TITLE
Consistency in README.md - Cursor manual install instructions should use @playwright/mcp@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For more information, see the [Codex MCP documentation](https://github.com/opena
 
 #### Or install manually:
 
-Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, use `command` type with the command `npx @playwright/mcp`. You can also verify config or add command like arguments via clicking `Edit`.
+Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, use `command` type with the command `npx @playwright/mcp@latest`. You can also verify config or add command like arguments via clicking `Edit`.
 
 </details>
 


### PR DESCRIPTION
Update README.md => Cursor manual setup instructions to use `@playwright/mcp@latest` for the command, vs. `@playwright/mcp`. 

Tested in Cursor 1.5.5

Why:

1.  Avoid pesky npx version issues, which may complicate some setups (see: https://github.com/npm/cli/issues/4108)
2. Remain consistent with pre-existing README.md guidance for installs - such as the below content: 

```
Standard config works in most of the tools:
e
{
  "mcpServers": {
    "playwright": {
      "command": "npx",
      "args": [
        "@playwright/mcp@latest"
      ]
    }
  }
}
```