### PR TITLE
feat: add browser_save_blob tool and improve file saving descriptions

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import blob from './tools/blob';
 import common from './tools/common';
 import console from './tools/console';
 import dialogs from './tools/dialogs';
@@ -36,6 +37,7 @@ import type { Tool } from './tools/tool';
 import type { FullConfig } from './config';
 
 export const allTools: Tool<any>[] = [
+  ...blob,
   ...common,
   ...console,
   ...dialogs,

--- a/src/tools/blob.ts
+++ b/src/tools/blob.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { z } from '../mcp/bundle.js';
+import { defineTabTool } from './tool';
+
+const saveBlobSchema = z.object({
+  blobUrl: z.string().optional().describe('Blob URL to save. If not provided, will attempt to find blob URLs in the current page.'),
+  filename: z.string().optional().describe('File name only (not a full path) to save the blob to. The file will be automatically saved to the MCP server\'s configured output directory for security. You cannot specify arbitrary paths. Defaults to `blob-{timestamp}.{extension}` where extension is guessed from content type.'),
+});
+
+const saveBlob = defineTabTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_save_blob',
+    title: 'Save blob URL',
+    description: 'Save content from a blob URL (e.g., PDFs opened in browser viewer) to a file',
+    inputSchema: saveBlobSchema,
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response) => {
+    let targetBlobUrl = params.blobUrl;
+
+    // If no blob URL provided, try to find one in the current page
+    if (!targetBlobUrl) {
+      const currentUrl = tab.page.url();
+      if (currentUrl.startsWith('blob:')) {
+        targetBlobUrl = currentUrl;
+      } else {
+        // Look for blob URLs in iframes or embed elements
+        const foundBlobUrls = await tab.page.evaluate(() => {
+          const blobUrls: string[] = [];
+
+          // Check iframes
+          const iframes = document.querySelectorAll('iframe');
+          iframes.forEach(iframe => {
+            const src = iframe.getAttribute('src');
+            if (src && src.startsWith('blob:'))
+              blobUrls.push(src);
+
+          });
+
+          // Check embed/object elements
+          const embeds = document.querySelectorAll('embed, object');
+          embeds.forEach(elem => {
+            const src = elem.getAttribute('src') || elem.getAttribute('data');
+            if (src && src.startsWith('blob:'))
+              blobUrls.push(src);
+
+          });
+
+          return blobUrls;
+        });
+
+        if (foundBlobUrls.length > 0) {
+          targetBlobUrl = foundBlobUrls[0];
+          if (foundBlobUrls.length > 1)
+            response.addResult(`Found ${foundBlobUrls.length} blob URLs, using the first one: ${targetBlobUrl}`);
+
+        }
+      }
+    }
+
+    if (!targetBlobUrl)
+      throw new Error('No blob URL found. Please provide a blob URL or navigate to a page with blob content.');
+
+
+    if (!targetBlobUrl.startsWith('blob:'))
+      throw new Error('Provided URL is not a blob URL. Only blob: URLs are supported.');
+
+
+    // Fetch blob content and convert to Base64
+    response.addCode(`// Fetch blob content from ${targetBlobUrl}`);
+    const result = await tab.page.evaluate(async blobUrl => {
+      try {
+        const response = await fetch(blobUrl);
+        const blob = await response.blob();
+
+        return new Promise<{base64Data: string, contentType: string, size: number}>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const result = reader.result as string;
+            const base64Data = result.split(',')[1];
+            resolve({
+              base64Data,
+              contentType: blob.type || 'application/octet-stream',
+              size: blob.size
+            });
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+      } catch (error) {
+        throw new Error(`Failed to fetch blob: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }, targetBlobUrl);
+
+    // Determine file extension from content type
+    const getExtensionFromContentType = (contentType: string): string => {
+      if (contentType.includes('pdf'))
+        return 'pdf';
+      if (contentType.includes('png'))
+        return 'png';
+      if (contentType.includes('jpeg') || contentType.includes('jpg'))
+        return 'jpg';
+      if (contentType.includes('gif'))
+        return 'gif';
+      if (contentType.includes('webp'))
+        return 'webp';
+      if (contentType.includes('svg'))
+        return 'svg';
+      if (contentType.includes('json'))
+        return 'json';
+      if (contentType.includes('text'))
+        return 'txt';
+      if (contentType.includes('html'))
+        return 'html';
+      return 'bin';
+    };
+
+    const extension = getExtensionFromContentType(result.contentType);
+    const fileName = await tab.context.outputFile(
+        params.filename ?? `blob-${new Date().toISOString().replace(/[:.]/g, '-')}.${extension}`
+    );
+
+    // Convert Base64 to buffer and save file
+    response.addCode(`const response = await fetch(blobUrl);
+const blob = await response.blob();
+// Convert blob to base64 and save to ${fileName}`);
+
+    const buffer = Buffer.from(result.base64Data, 'base64');
+    fs.writeFileSync(fileName, buffer);
+
+    response.addResult(`Saved blob content to file (${result.size} bytes, ${result.contentType}). Full path: ${fileName}`);
+  },
+});
+
+export default [
+  saveBlob,
+];

--- a/src/tools/pdf.ts
+++ b/src/tools/pdf.ts
@@ -19,7 +19,7 @@ import { defineTabTool } from './tool';
 import * as javascript from '../utils/codegen.js';
 
 const pdfSchema = z.object({
-  filename: z.string().optional().describe('File name to save the pdf to. Defaults to `page-{timestamp}.pdf` if not specified.'),
+  filename: z.string().optional().describe('File name only (not a full path) to save the PDF to. The file will be automatically saved to the MCP server\'s configured output directory for security. You cannot specify arbitrary paths. Defaults to `page-{timestamp}.pdf` if not specified.'),
 });
 
 const pdf = defineTabTool({
@@ -36,7 +36,7 @@ const pdf = defineTabTool({
   handle: async (tab, params, response) => {
     const fileName = await tab.context.outputFile(params.filename ?? `page-${new Date().toISOString()}.pdf`);
     response.addCode(`await page.pdf(${javascript.formatObject({ path: fileName })});`);
-    response.addResult(`Saved page as ${fileName}`);
+    response.addResult(`Saved page as PDF. Full path: ${fileName}`);
     await tab.page.pdf({ path: fileName });
   },
 });

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -23,7 +23,7 @@ import type * as playwright from 'playwright';
 
 const screenshotSchema = z.object({
   type: z.enum(['png', 'jpeg']).default('png').describe('Image format for the screenshot. Default is png.'),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
+  filename: z.string().optional().describe('File name only (not a full path) to save the screenshot to. The file will be automatically saved to the MCP server\'s configured output directory for security. You cannot specify arbitrary paths. Defaults to `page-{timestamp}.{png|jpeg}` if not specified.'),
   element: z.string().optional().describe('Human-readable element description used to obtain permission to screenshot the element. If not provided, the screenshot will be taken of viewport. If element is provided, ref must be provided too.'),
   ref: z.string().optional().describe('Exact target element reference from the page snapshot. If not provided, the screenshot will be taken of viewport. If ref is provided, element must be provided too.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
@@ -73,7 +73,7 @@ const screenshot = defineTabTool({
       response.addCode(`await page.screenshot(${javascript.formatObject(options)});`);
 
     const buffer = locator ? await locator.screenshot(options) : await tab.page.screenshot(options);
-    response.addResult(`Took the ${screenshotTarget} screenshot and saved it as ${fileName}`);
+    response.addResult(`Took the ${screenshotTarget} screenshot. Full path: ${fileName}`);
 
     // https://github.com/microsoft/playwright-mcp/issues/817
     // Never return large images to LLM, saving them to the file system is enough.

--- a/tests/blob.spec.ts
+++ b/tests/blob.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+
+import { test, expect } from './fixtures';
+
+test('browser_save_blob with text blob', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    pageState: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+
+  // Create a text blob with known content and get its URL
+  const blobResult = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: `() => {
+        const content = "Hello, this is test content for blob saving!";
+        const blob = new Blob([content], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        
+        // Store the blob globally so it can be accessed later
+        window.testBlob = blob;
+        window.testBlobUrl = url;
+        
+        return url;
+      }`,
+    },
+  });
+
+  // Extract the actual blob URL from the formatted response
+  const responseText = blobResult.content[0].text;
+  const blobUrlMatch = responseText.match(/"(blob:http[^"]+)"/);
+  if (!blobUrlMatch) {
+    throw new Error(`Could not extract blob URL from response: ${responseText}`);
+  }
+  const blobUrl = blobUrlMatch[1];
+
+  // Test saving the blob
+  expect(await client.callTool({
+    name: 'browser_save_blob',
+    arguments: {
+      blobUrl,
+      filename: 'test.txt',
+    },
+  })).toHaveResponse({
+    result: expect.stringContaining('test.txt'),
+  });
+
+  // Verify file was created
+  const files = [...fs.readdirSync(outputDir)];
+  const txtFiles = files.filter(f => f.endsWith('.txt'));
+  expect(txtFiles).toHaveLength(1);
+  expect(txtFiles[0]).toMatch(/^test\.txt$/);
+
+  // Verify file content
+  const savedContent = fs.readFileSync(`${outputDir}/test.txt`, 'utf8');
+  expect(savedContent).toBe('Hello, this is test content for blob saving!');
+});
+
+test('browser_save_blob auto-detection with iframe', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    pageState: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+
+  // Create a blob URL and add it to an iframe
+  await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: `() => {
+        const content = "Auto-detected blob content!";
+        const blob = new Blob([content], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        
+        // Create an iframe with the blob URL
+        const iframe = document.createElement('iframe');
+        iframe.src = url;
+        document.body.appendChild(iframe);
+        
+        return url;
+      }`,
+    },
+  });
+
+  // Test auto-detection (no blobUrl specified)
+  expect(await client.callTool({
+    name: 'browser_save_blob',
+    arguments: {
+      filename: 'auto-detected.txt',
+    },
+  })).toHaveResponse({
+    result: expect.stringContaining('auto-detected.txt'),
+  });
+
+  // Verify file was created
+  const files = [...fs.readdirSync(outputDir)];
+  const txtFiles = files.filter(f => f.endsWith('.txt'));
+  expect(txtFiles).toHaveLength(1);
+  expect(txtFiles[0]).toMatch(/^auto-detected\.txt$/);
+
+  // Verify file content
+  const savedContent = fs.readFileSync(`${outputDir}/auto-detected.txt`, 'utf8');
+  expect(savedContent).toBe('Auto-detected blob content!');
+});
+
+test('browser_save_blob error when no blob URL found', async ({ startClient, server }) => {
+  const { client } = await startClient();
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    pageState: expect.stringContaining(`Hello, world!`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_save_blob',
+  })).toHaveResponse({
+    result: 'Error: No blob URL found. Please provide a blob URL or navigate to a page with blob content.',
+    isError: true,
+  });
+});
+
+test('browser_save_blob error with non-blob URL', async ({ startClient, server }) => {
+  const { client } = await startClient();
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    pageState: expect.stringContaining(`Hello, world!`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_save_blob',
+    arguments: {
+      blobUrl: 'https://example.com/file.pdf',
+    },
+  })).toHaveResponse({
+    result: 'Error: Provided URL is not a blob URL. Only blob: URLs are supported.',
+    isError: true,
+  });
+});


### PR DESCRIPTION
## Summary
  - Adds new `browser_save_blob` tool to handle the classic Playwright problem of saving blob URLs (e.g., PDFs opened in browser viewers)
  - Improves file saving descriptions across all tools for better LLM understanding

  ## Changes
  ### New Tool: `browser_save_blob`
  - Automatically detects blob URLs in current page, iframes, and embed elements
  - Supports manual blob URL specification with filename parameter
  - Determines file extension from content type (PDF, PNG, JPG, etc.)
  - Uses same secure file saving mechanism as other tools

  ### Improved File Saving Descriptions
  - Updated `browser_pdf_save`, `browser_take_screenshot`, and `browser_save_blob` descriptions
  - Clarifies that files are saved to MCP server's configured output directory only
  - Explains that arbitrary paths cannot be specified for security
  - All tools now return full paths in results for LLM assurance

  **Rationale**: Testing revealed that most LLMs (Claude, Gemini, Codex) got confused about where screenshots and PDF saves were being sent. They attempted to use        
  full path parameters, which just ended up becoming filenames with dashes instead of slashes, causing confusion about file locations.

  ## Test Coverage
  - ✅ Manual blob URL with filename - Creates text blob, saves with specified filename, verifies content
  - ✅ Auto-detection with iframe - Creates blob in iframe, auto-detects and saves
  - ✅ Error handling for missing blob URLs
  - ✅ Error handling for invalid non-blob URLs
  Tests follow same patterns as existing PDF/screenshot tests

  ## Test plan
  - [x] Tool compiles and builds successfully
  - [x] Tool is properly registered in the tools system
  - [x] Descriptions are clear and consistent across all file-saving tools
  - [x] Comprehensive test coverage with actual file verification