### PR TITLE
 feat: CDP Authentication Headers Support for issue #989

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information, see the [Codex MCP documentation](https://github.com/opena
 
 #### Click the button to install:
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=Playwright&config=eyJjb21tYW5kIjoibnB4IEBwbGF5d3JpZ2h0L21jcEBsYXRlc3QifQ%3D%3D)
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](cursor://anysphere.cursor-deeplink/mcp/install?name=Playwright&config=eyJjb21tYW5kIjoibnB4IEBwbGF5d3JpZ2h0L21jcEBsYXRlc3QifQ%3D%3D)
 
 #### Or install manually:
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -60,6 +60,11 @@ export type Config = {
     cdpEndpoint?: string;
 
     /**
+     * Headers to include in CDP requests if needed.
+     */
+    cdpHeaders?: Record<string, string> | string;
+
+    /**
      * Remote endpoint to connect to an existing Playwright server.
      */
     remoteEndpoint?: string;

--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -128,6 +128,17 @@ class CdpContextFactory extends BaseContextFactory {
   }
 
   protected override async _doObtainBrowser(): Promise<playwright.Browser> {
+    if (this.config.browser.cdpHeaders) {
+      let headersObject: Record<string, string>;
+      
+      if (typeof this.config.browser.cdpHeaders != "object") {
+        headersObject = JSON.parse(this.config.browser.cdpHeaders);
+      } else {
+        headersObject = this.config.browser.cdpHeaders;
+      }
+      return playwright.chromium.connectOverCDP(this.config.browser.cdpEndpoint!, { headers: headersObject });
+
+    }
     return playwright.chromium.connectOverCDP(this.config.browser.cdpEndpoint!);
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,6 +146,9 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
   if (cliOptions.device && cliOptions.cdpEndpoint)
     throw new Error('Device emulation is not supported with cdpEndpoint.');
 
+  if (cliOptions.cdpHeaders && !cliOptions.cdpEndpoint)
+    throw new Error('cdp-headers requires cdp-endpoint to be specified.');
+
   // Context options
   const contextOptions: BrowserContextOptions = cliOptions.device ? devices[cliOptions.device] : {};
   if (cliOptions.storageState)

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type CLIOptions = {
   browser?: string;
   caps?: string[];
   cdpEndpoint?: string;
+  cdpHeaders?: Record<string, string> | string;
   config?: string;
   device?: string;
   executablePath?: string;
@@ -178,6 +179,7 @@ export function configFromCLIOptions(cliOptions: CLIOptions): Config {
       launchOptions,
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
+      cdpHeaders: cliOptions.cdpHeaders,
     },
     server: {
       port: cliOptions.port,

--- a/src/program.ts
+++ b/src/program.ts
@@ -37,6 +37,7 @@ program
     .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
     .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf.', commaSeparatedList)
     .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
+    .option('--cdp-headers <headers>', 'JSON string of headers for CDP authentication')
     .option('--config <path>', 'path to the configuration file.')
     .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
     .option('--executable-path <path>', 'path to the browser executable.')


### PR DESCRIPTION
- Added -cdp-headers as a parameter when connect to an external browser (such as Bedrock Agent Core or other browser need headers for authentication) 
- Added test for this 