### PR TITLE
Fix Docker path issue with Claude Code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ FROM base
 ARG PLAYWRIGHT_BROWSERS_PATH
 ARG USERNAME=node
 ENV NODE_ENV=production
+ENV PLAYWRIGHT_MCP_OUTPUT_DIR=/tmp/playwright-output
 
 # Set the correct ownership for the runtime user on production `node_modules`
 RUN chown -R ${USERNAME}:${USERNAME} node_modules


### PR DESCRIPTION
Set PLAYWRIGHT_MCP_OUTPUT_DIR to prevent the container from trying to create host filesystem paths when Claude Code passes rootPath from the host system. This resolves 'EACCES: permission denied, mkdir /Users' errors.