### PR TITLE
Fix programmatic usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ http.createServer(async (req, res) => {
   // Creates a headless Playwright MCP server with SSE transport
   const connection = await createConnection({ browser: { launchOptions: { headless: true } } });
   const transport = new SSEServerTransport('/messages', res);
-  await connection.server.connect(transport);
+  await connection.connect(transport);
 
   // ...
 });


### PR DESCRIPTION
This PR fixes a small typo: there is no `connection.sever.connect`, but instead is just `connection.connect`. The server itself is not exposed. IMO it should be so developers can extend it programmatically with their own tools, but that's likely a discussion for another time. :) 