### PR TITLE
Fix broken installation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ claude mcp add playwright npx @playwright/mcp@latest
 <details>
 <summary>Claude Desktop</summary>
 
-Follow the MCP install [guide](https://modelcontextprotocol.io/quickstart/user), use the standard config above.
+Follow the MCP install [guide](https://modelcontextprotocol.info/docs/quickstart/user/), use the standard config above.
 
 </details>
 


### PR DESCRIPTION
The previous installation link in the README was outdated and no longer accessible.   It has been replaced with the correct and working link:

https://modelcontextprotocol.info/docs/quickstart/user/

This ensures that users can follow the documentation without encountering errors.

Cheers.-
QA Tester derlisdev@gmail.com