### PR TITLE
Update README.md:  Running the Playwright-MCP server in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,19 @@ And then in MCP client config, set the `url` to the HTTP endpoint:
 }
 ```
 
+Or If you prefer to run the container as a long-lived service instead of letting the MCP client spawn it, use:
+
+```
+docker run -d -i --rm --init --pull=always \
+  --entrypoint node \
+  --name playwright \
+  -p 8931:8931 \
+  mcr.microsoft.com/playwright/mcp \
+  cli.js --headless --browser chromium --no-sandbox --port 8931
+```
+
+The server will listen on host port **8931** and can be reached by any MCP client.  
+
 You can build the Docker image yourself.
 
 ```


### PR DESCRIPTION
Expose the service on port 8931: 

```
docker run -d -i --rm --init --pull=always --entrypoint node --name playwright -p 8931:8931 "mcr.microsoft.com/playwright/mcp" cli.js --headless --browser chromium --no-sandbox --port 8931
```

The container is then reachable at http://localhost:8931/mcp.

<img width="1110" height="784" alt="image" src="https://github.com/user-attachments/assets/b1cc3f13-330d-49dc-ad43-c553b0160896" />



