### PR TITLE
docs: add codex CLI command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ Follow the MCP install [guide](https://modelcontextprotocol.io/quickstart/user),
 <details>
 <summary>Codex</summary>
 
-Create or edit the configuration file `~/.codex/config.toml` and add:
+Use the Codex CLI to add the Playwright MCP server:
+
+```bash
+codex mcp add playwright npx "@playwright/mcp@latest"
+```
+
+Alternatively, create or edit the configuration file `~/.codex/config.toml` and add:
 
 ```toml
 [mcp_servers.playwright]


### PR DESCRIPTION
Add the `codex mcp add` command as the primary installation method for Codex, with manual config.toml editing as an alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)