### PR TITLE
docs: add Factory installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, u
 </details>
 
 <details>
+<summary>Factory</summary>
+
+Use the Factory CLI to add the Playwright MCP server:
+
+```bash
+droid mcp add playwright "npx @playwright/mcp@latest"
+```
+
+Alternatively, type `/mcp` within Factory droid to open an interactive UI for managing MCP servers.
+
+For more information, see the [Factory MCP documentation](https://docs.factory.ai/cli/configuration/mcp).
+
+</details>
+
+<details>
 <summary>Gemini CLI</summary>
 
 Follow the MCP install [guide](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#configure-the-mcp-server-in-settingsjson), use the standard config above.


### PR DESCRIPTION
This PR adds Factory as an installation option in the **Getting Started** section.

## Changes

Adds a new **Factory** section that includes:

### CLI Installation
- Command: `droid mcp add playwright "npx @playwright/mcp@latest"`
- Simple, single-line command for quick setup

### Interactive UI Option
- Instructions for using Factory's `/mcp` command to access an interactive UI for managing MCP servers

### Documentation Link
- Reference to Factory MCP documentation at https://docs.factory.ai/cli/configuration/mcp

## About Factory

[Factory](https://factory.ai) is an AI-powered software engineering platform that supports MCP servers through both CLI commands and an interactive UI.

## Placement

The Factory section is added in alphabetical order between **Cursor** and **Gemini CLI**, following the established format and structure of the existing installation instructions in the document.