### PR TITLE
feat: add --always-allow flag to bypass extension approval dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,21 @@ state [here](https://playwright.dev/docs/auth).
 
 The Playwright MCP Chrome Extension allows you to connect to existing browser tabs and leverage your logged-in sessions and browser state. See [extension/README.md](extension/README.md) for installation and setup instructions.
 
+To bypass the connection approval dialog on each session, you can use the `--always-allow` flag:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--extension", "--always-allow"]
+    }
+  }
+}
+```
+
+For better security, you can use a unique token from the extension instead of `--always-allow`. See the [extension README](extension/README.md) for details.
+
 ### Initial state
 
 There are multiple ways to provide the initial state to the browser context or a page.

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,17 @@
  * limitations under the License.
  */
 
+// Check for --always-allow flag and set the environment variable
+const args = process.argv.slice(2);
+const alwaysAllowIndex = args.indexOf('--always-allow');
+if (alwaysAllowIndex !== -1) {
+  // Set the environment variable to bypass extension approval
+  process.env.PLAYWRIGHT_MCP_EXTENSION_TOKEN = 'always-allow';
+  // Remove the flag from args so it doesn't cause an error in the main program
+  args.splice(alwaysAllowIndex, 1);
+  process.argv = [process.argv[0], process.argv[1], ...args];
+}
+
 const { program } = require('playwright-core/lib/utilsBundle');
 const { decorateCommand } = require('playwright/lib/mcp/program');
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -45,4 +45,52 @@ Configure Playwright MCP server to connect to the browser using the extension by
 
 When the LLM interacts with the browser for the first time, it will load a page where you can select which browser tab the LLM will connect to. This allows you to control which specific page the AI assistant will interact with during the session.
 
+### Bypassing the Connection Dialog
+
+By default, each new session requires manual approval through the extension's connection dialog. You can bypass this in two ways:
+
+#### Option 1: Using a Secure Token (Recommended)
+
+1. Open the extension by clicking the Playwright MCP Bridge icon in your browser
+2. Copy the `PLAYWRIGHT_MCP_EXTENSION_TOKEN` value shown
+3. Add it to your MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "playwright-extension": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--extension"
+      ],
+      "env": {
+        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+#### Option 2: Always Allow (Less Secure)
+
+If you want to always approve connections without a token (useful for development), use the `--always-allow` flag:
+
+```json
+{
+  "mcpServers": {
+    "playwright-extension": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--extension",
+        "--always-allow"
+      ]
+    }
+  }
+}
+```
+
+**Warning**: Using `--always-allow` means any MCP client can connect to your browser without approval. Only use this in trusted environments.
+
 

--- a/extension/src/ui/authToken.tsx
+++ b/extension/src/ui/authToken.tsx
@@ -43,6 +43,9 @@ export const AuthTokenSection: React.FC<{}> = ({}) => {
         <button className='auth-token-refresh' title='Generate new token' aria-label='Generate new token'onClick={onRegenerateToken}>{icons.refresh()}</button>
         <CopyToClipboard value={authTokenCode(authToken)} />
       </div>
+      <div className='auth-token-description' style={{ marginTop: '8px', fontSize: '11px' }}>
+        Or use the <code style={{ padding: '2px 4px', backgroundColor: '#e1e4e8', borderRadius: '3px' }}>--always-allow</code> flag to always approve connections without a token.
+      </div>
 
       <div className='auth-token-example-section'>
         <button

--- a/extension/src/ui/connect.tsx
+++ b/extension/src/ui/connect.tsx
@@ -81,7 +81,8 @@ const ConnectApp: React.FC = () => {
 
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
-      if (token === expectedToken) {
+      // Support "always-allow" as a special token value to bypass approval
+      if (token === 'always-allow' || token === expectedToken) {
         await connectToMCPRelay(relayUrl);
         await handleConnectToTab();
         return;

--- a/extension/tests/extension.spec.ts
+++ b/extension/tests/extension.spec.ts
@@ -331,6 +331,26 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   expect(await navigateResponse).toHaveResponse({
     pageState: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
+});
 
+test(`bypass connection dialog with always-allow flag`, async ({ browserWithExtension, startClient, server }) => {
+  await browserWithExtension.launch();
 
+  const { client } = await startClient({
+    args: [`--extension`, `--always-allow`],
+    config: {
+      browser: {
+        userDataDir: browserWithExtension.userDataDir,
+      }
+    },
+  });
+
+  const navigateResponse = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  expect(await navigateResponse).toHaveResponse({
+    pageState: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
 });


### PR DESCRIPTION
I use the extension when im away from computer. there has been recent changes that require the user to approve every session. this PR is to enable a way to always approve all extension sessions

This commit adds a new --always-allow command-line flag that allows users to bypass the browser extension connection approval dialog on each session.

Changes:
- Added CLI wrapper in cli.js to intercept --always-allow flag
- Modified extension to recognize 'always-allow' as a special token value
- Updated documentation in README.md and extension/README.md
- Updated extension UI to show the --always-allow option
- Added test case for the new flag

The flag sets PLAYWRIGHT_MCP_EXTENSION_TOKEN=always-allow internally, providing a cleaner API than requiring users to set environment variables.

Usage:
  npx @playwright/mcp@latest --extension --always-allow

Security note: This flag should only be used in trusted development environments as it allows any MCP client to connect without approval.