### PR TITLE
Update version to 0.0.47 in server.json

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/microsoft/playwright-mcp",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@playwright/mcp",
-      "version": "0.0.46",
+      "version": "0.0.47",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
This other version bump happened while the server.json PR was still open :)
https://github.com/microsoft/playwright-mcp/pull/1198