### PR TITLE
Add authentication token documentation to extension README

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -45,4 +45,33 @@ Configure Playwright MCP server to connect to the browser using the extension by
 
 When the LLM interacts with the browser for the first time, it will load a page where you can select which browser tab the LLM will connect to. This allows you to control which specific page the AI assistant will interact with during the session.
 
+### Bypassing the Connection Approval Dialog
+
+By default, you'll need to approve each connection when the MCP server tries to connect to your browser. To bypass this approval dialog and allow automatic connections, you can use an authentication token.
+
+#### Using Your Unique Authentication Token
+
+1. After installing the extension, click on the extension icon or navigate to the extension's status page
+2. Copy the `PLAYWRIGHT_MCP_EXTENSION_TOKEN` value displayed in the extension UI
+3. Add it to your MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "playwright-extension": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--extension"
+      ],
+      "env": {
+        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "your-token-here"
+      }
+    }
+  }
+}
+```
+
+This token is unique to your browser profile and provides secure authentication between the MCP server and the extension. Once configured, you won't need to manually approve connections each time.
+
 


### PR DESCRIPTION
# Add authentication token documentation to extension README

## Summary

This PR adds documentation to the extension README explaining how users can use the `PLAYWRIGHT_MCP_EXTENSION_TOKEN` environment variable to bypass the connection approval dialog.

## Motivation

Currently, users need to manually approve each connection when the MCP server tries to connect to the browser extension. While the authentication token feature already exists in the codebase, it's not documented in the extension README, making it difficult for users to discover this time-saving feature.

## Changes

- **Documentation** (`extension/README.md`): Added a new section "Bypassing the Connection Approval Dialog" that explains:
  - How to find the unique authentication token in the extension UI
  - How to configure the token in the MCP server configuration
  - The benefits of using the token (no manual approval needed for each session)

## Usage

After this documentation is available, users can configure their MCP client like this:

```json
{
  "mcpServers": {
    "playwright-extension": {
      "command": "npx",
      "args": [
        "@playwright/mcp@latest",
        "--extension"
      ],
      "env": {
        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "their-unique-token-here"
      }
    }
  }
}
```

## Benefits

- Improves user experience by documenting an existing feature
- Reduces friction for users who frequently restart their MCP sessions
- Provides clear, copy-paste ready configuration examples
- No code changes required - purely documentation

## Testing

- ✅ Documentation reviewed for accuracy
- ✅ Configuration example matches existing implementation
- ✅ Token mechanism already exists and is tested in the codebase

## Related

This documents the existing authentication token feature that's implemented in:
- `extension/src/ui/authToken.tsx` - Token generation and display
- `extension/src/ui/connect.tsx` - Token validation logic

