### PR TITLE
docs: clarify --executable-path only works with Chromium browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ Playwright MCP server supports following arguments. They can be provided in the 
 
 <!--- End of options generated section -->
 
+> **Note:** The `--executable-path` option only works with Chromium-family browsers (Chromium, Chrome, Edge). For Firefox and WebKit, Playwright will use its bundled browser versions regardless of this option.
+
 ### User profile
 
 You can run Playwright MCP with persistent profile like a regular browser (default), in isolated contexts for testing sessions, or connect to your existing browser using the browser extension.


### PR DESCRIPTION
## Summary

- Adds documentation clarifying that `--executable-path` only works with Chromium-family browsers
- Places the note prominently after the Configuration options section in README

## Context

As discussed in #605, users were confused when trying to use `--executable-path` with Firefox, which is not supported. The `--executable-path` option only works with Chromium-family browsers (Chromium, Chrome, Edge). Firefox and WebKit will always use Playwright's bundled browser versions.

This documentation change makes this limitation explicit, similar to how the `--extension` option clearly indicates it's "Edge/Chrome only".

Fixes #605