### PR TITLE
docs: point to monorepo for the source code

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,3 @@
 # Where is the source?
 
-Playwright MCP source code is located in the Playwright monorepo. Please refer to the contributor's guide in [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.
+Playwright MCP source code is located in the [Playwright monorepo](https://github.com/microsoft/playwright/blob/main/packages/playwright/src/mcp). Please refer to the contributor's guide in [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.


### PR DESCRIPTION
Updates documentation to guide users to the monorepo, making it easier to find the source code.