### PR TITLE
fix: update extension README link to packages/extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ state [here](https://playwright.dev/docs/auth).
 
 **Browser Extension**
 
-The Playwright MCP Chrome Extension allows you to connect to existing browser tabs and leverage your logged-in sessions and browser state. See [extension/README.md](extension/README.md) for installation and setup instructions.
+The Playwright MCP Chrome Extension allows you to connect to existing browser tabs and leverage your logged-in sessions and browser state. See [packages/extension/README.md](packages/extension/README.md) for installation and setup instructions.
 
 ### Initial state
 


### PR DESCRIPTION
## Summary
- Fixed broken link to extension README after monorepo restructuring

## Details
After the monorepo restructuring in #1325, the extension was moved from `extension/` to `packages/extension/`, but the README link wasn't updated. This PR fixes the broken link.

## Changes
- Updated `extension/README.md` → `packages/extension/README.md` in main README

🤖 Generated with [Claude Code](https://claude.com/claude-code)