### PR TITLE
docs: add --host 0.0.0.0 to Docker service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ docker run -d -i --rm --init --pull=always \
   --name playwright \
   -p 8931:8931 \
   mcr.microsoft.com/playwright/mcp \
-  cli.js --headless --browser chromium --no-sandbox --port 8931
+  cli.js --headless --browser chromium --no-sandbox --port 8931 --host 0.0.0.0
 ```
 
 The server will listen on host port **8931** and can be reached by any MCP client.  


### PR DESCRIPTION
When running the container as a long-lived service with port mapping (`-p 8931:8931`), the MCP server binds to `localhost` by default inside the container, making it unreachable from the Docker host.

Adding `--host 0.0.0.0` to the example ensures the server listens on all interfaces so the MCP client can connect through the mapped port.

Fixes #1370