### PR TITLE
Add Antigravity to MCP client list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ amp mcp add playwright -- npx @playwright/mcp@latest
 </details>
 
 <details>
+<summary>Antigravity</summary>
+
+Add via the Antigravity settings or by updating your configuration file:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
 <summary>Claude Code</summary>
 
 Use the Claude Code CLI to add the Playwright MCP server:


### PR DESCRIPTION
This PR adds Antigravity as a supported MCP client in the README.md file.

        ## Changes:
        - Adds Antigravity configuration section in alphabetical order (between Amp and Claude Code)
        - Follows the same format as other MCP client entries
        - Includes standard configuration with npx command

        This allows Antigravity users to easily configure the Playwright MCP server.