### PR TITLE
docs: add AdaL CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package provides MCP interface into Playwright. If you are using a **coding
 
 ### Requirements
 - Node.js 18 or newer
-- VS Code, Cursor, Windsurf, Claude Desktop, Goose or any other MCP client
+- VS Code, Cursor, Windsurf, Claude Desktop, Goose, AdaL CLI or any other MCP client
 
 <!--
 // Generate using:
@@ -323,6 +323,25 @@ Alternatively, use the slash command `/add-mcp` in the Warp prompt and paste the
 <summary>Windsurf</summary>
 
 Follow Windsurf MCP [documentation](https://docs.windsurf.com/windsurf/cascade/mcp). Use the standard config above.
+
+</details>
+
+<details>
+<summary>AdaL CLI</summary>
+
+Use the AdaL CLI to add the Playwright MCP server:
+
+```bash
+/mcp add playwright --command npx --args "-y,@playwright/mcp@latest"
+```
+
+For the standalone HTTP server:
+
+```bash
+/mcp add playwright --transport http --url http://localhost:8931/mcp
+```
+
+For more information, see the [AdaL CLI documentation](https://github.com/SylphAI-Inc/adal-cli).
 
 </details>
 


### PR DESCRIPTION
## Add AdaL CLI installation instructions

This PR adds [AdaL CLI](https://github.com/SylphAI-Inc/adal-cli) setup instructions to the Playwright MCP documentation, alongside existing client configurations (VS Code, Cursor, Claude Code, Windsurf, etc.).

### Changes

- **README.md**: Added AdaL CLI to the Requirements section and included a new `<details>` block with setup instructions for both local (npx) and standalone HTTP server configurations.

### Why

AdaL CLI is a unified terminal-based AI agent with growing adoption. Adding it to the supported clients list helps developers who use AdaL CLI discover and configure the Playwright MCP server seamlessly, just like they can with Cursor, Claude Code, or any other listed client.

### Details

- AdaL CLI is placed as the last entry in the client list, respecting the existing order.
- Instructions follow the standard AdaL CLI `/mcp add` syntax for both local and HTTP transport modes.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
