### PR TITLE
chore: add MCP manifest for npx launcher

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "short_name": "playwright",
+  "description": "Microsoft Playwright MCP server (npm package)",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@playwright/mcp@latest"
+  ],
+  "env": {}
+}


### PR DESCRIPTION
Adds a local `mcp.json` manifest for launcher-based integration:

- defines `short_name` as `playwright`
- uses `npx -y @playwright/mcp@latest`
- provides description/env block for manifest-driven MCP installers

This mirrors the repo-local setup used in downstream MCP bundles.
