### PR TITLE
feat(package): add `mcpName` field for MCP Registry ownership verification

### DIFF
--- a/packages/playwright-mcp/package.json
+++ b/packages/playwright-mcp/package.json
@@ -2,7 +2,6 @@
   "name": "@playwright/mcp",
   "version": "0.0.68",
   "description": "Playwright Tools for MCP",
-  "mcpName": "com.microsoft/playwright-mcp",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/microsoft/playwright-mcp.git"
@@ -15,6 +14,7 @@
     "name": "Microsoft Corporation"
   },
   "license": "Apache-2.0",
+  "mcpName": "io.github.microsoft/playwright-mcp",
   "scripts": {
     "lint": "node update-readme.js",
     "test": "playwright test",


### PR DESCRIPTION
The [MCP Registry](https://github.com/modelcontextprotocol/registry) verifies npm package ownership by checking for an `mcpName` field in `package.json`. Without it, publishing `com.microsoft/playwright-mcp` fails with:

```
NPM package '@playwright/mcp' is missing required 'mcpName' field.
Add this to your package.json: "mcpName": "com.microsoft/playwright-mcp"
```

This one-line addition allows the registry to validate that `@playwright/mcp` belongs to `com.microsoft/playwright-mcp`.