### PR TITLE
fix(extension): arm inactivity timers for all pending tabs

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -190,7 +190,6 @@ class TabShareExtension {
             chrome.tabs.sendMessage(tabId, { type: 'connectionTimeout' });
           }
         }, 5000);
-        return;
       }
     }
   }


### PR DESCRIPTION
## Summary
This patch fixes a control-flow bug in the extension background script where `_onTabActivated` would stop after scheduling a timeout for the first inactive pending tab.

With multiple entries in `_pendingTabSelection`, only one tab got timeout handling per activation event.

## Changes
- Remove the early `return` in `TabShareExtension._onTabActivated` so the loop evaluates all pending tabs.

## Why
Without this, inactive pending tabs can remain pending indefinitely (unless another tab activation happens to process them later), which may leave stale relay connection state around longer than intended.

## Validation
- `npm run lint --workspace @playwright/mcp-extension`
- `npm run test --workspace @playwright/mcp-extension -- --list`

Fixes #1442