### PR TITLE
fix: sanitize malformed Unicode in MCP responses

### DIFF
--- a/packages/playwright-mcp/cli.js
+++ b/packages/playwright-mcp/cli.js
@@ -16,9 +16,81 @@
  */
 
 const { program } = require('playwright-core/lib/utilsBundle');
+const mcpBundle = require('playwright-core/lib/mcpBundle');
 const { decorateMCPCommand } = require('playwright/lib/mcp/program');
 
 const packageJSON = require('./package.json');
-const p = program.version('Version ' + packageJSON.version).name('Playwright MCP');
-decorateMCPCommand(p, packageJSON.version)
-void program.parseAsync(process.argv);
+
+function sanitizeString(value) {
+  if (typeof value !== 'string')
+    return value;
+  if (typeof value.toWellFormed === 'function')
+    return value.toWellFormed();
+
+  let result = '';
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xDC00 && next <= 0xDFFF) {
+        result += value[index] + value[index + 1];
+        index++;
+      } else {
+        result += '\uFFFD';
+      }
+      continue;
+    }
+    if (code >= 0xDC00 && code <= 0xDFFF) {
+      result += '\uFFFD';
+      continue;
+    }
+    result += value[index];
+  }
+  return result;
+}
+
+function sanitizeDeep(value) {
+  if (typeof value === 'string')
+    return sanitizeString(value);
+  if (Array.isArray(value))
+    return value.map(sanitizeDeep);
+  if (!value || typeof value !== 'object')
+    return value;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null)
+    return value;
+  return Object.fromEntries(Object.entries(value).map(([key, nestedValue]) => [key, sanitizeDeep(nestedValue)]));
+}
+
+function patchTransportSend(Transport) {
+  const originalSend = Transport?.prototype?.send;
+  if (typeof originalSend !== 'function' || originalSend.__playwrightMcpUnicodeSafe)
+    return;
+  const wrappedSend = function(message, ...args) {
+    return originalSend.call(this, sanitizeDeep(message), ...args);
+  };
+  wrappedSend.__playwrightMcpUnicodeSafe = true;
+  Transport.prototype.send = wrappedSend;
+}
+
+function installUnicodeSafeSerialization() {
+  patchTransportSend(mcpBundle.StdioServerTransport);
+  patchTransportSend(mcpBundle.SSEServerTransport);
+  patchTransportSend(mcpBundle.StreamableHTTPServerTransport);
+}
+
+function run() {
+  installUnicodeSafeSerialization();
+  const p = program.version('Version ' + packageJSON.version).name('Playwright MCP');
+  decorateMCPCommand(p, packageJSON.version);
+  return program.parseAsync(process.argv);
+}
+
+module.exports = {
+  installUnicodeSafeSerialization,
+  sanitizeDeep,
+  sanitizeString,
+};
+
+if (require.main === module)
+  void run();

--- a/packages/playwright-mcp/tests/unicode-serialization.spec.ts
+++ b/packages/playwright-mcp/tests/unicode-serialization.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+const mcpBundle = require('playwright-core/lib/mcpBundle');
+const { installUnicodeSafeSerialization } = require('../cli.js');
+
+function createTransport() {
+  let serialized = '';
+  const transport = Object.create(mcpBundle.StdioServerTransport.prototype);
+  transport._stdout = {
+    write(chunk: string) {
+      serialized += chunk;
+      return true;
+    },
+    once() {},
+  };
+  return {
+    transport,
+    readMessage: () => JSON.parse(serialized.trim()),
+  };
+}
+
+test('sanitizes malformed unicode in outgoing stdio messages', async () => {
+  installUnicodeSafeSerialization();
+  const { transport, readMessage } = createTransport();
+
+  await transport.send({
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      content: [{ type: 'text', text: `before ${String.fromCharCode(0xD800)} after` }],
+    },
+  });
+
+  expect(readMessage().result.content[0].text).toBe('before \uFFFD after');
+});
+
+test('preserves non-plain values that JSON.stringify already handles', async () => {
+  installUnicodeSafeSerialization();
+  const { transport, readMessage } = createTransport();
+
+  await transport.send({
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      when: new Date('2024-01-02T03:04:05.000Z'),
+    },
+  });
+
+  expect(readMessage().result.when).toBe('2024-01-02T03:04:05.000Z');
+});


### PR DESCRIPTION
## Summary
- sanitize malformed Unicode just before MCP transport sends responses over stdio, SSE, and streamable HTTP
- preserve non-plain values that already serialize correctly while repairing lone surrogate text content
- add regression coverage for malformed Unicode transport output and non-plain value preservation

## Testing
- `npx playwright test tests/unicode-serialization.spec.ts`
- `node packages/playwright-mcp/cli.js --help`

Closes #1447