### PR TITLE
feat(extension): inject public key into release zip to preserve Web Store extension ID

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,8 @@ jobs:
       - name: Build extension
         working-directory: ./packages/extension
         run: npm run build
+        env:
+          SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST: 1
       - name: Get extension version
         id: get-version
         working-directory: ./packages/extension

--- a/packages/extension/vite.config.mts
+++ b/packages/extension/vite.config.mts
@@ -19,6 +19,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
+// Public key matching the Chrome Web Store listing — used to fix the extension ID across installs.
+// Set SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST=1 in release builds to inject it into the manifest.
+const extensionPublicKey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB';
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -31,7 +35,14 @@ export default defineConfig({
         },
         {
           src: '../../manifest.json',
-          dest: '.'
+          dest: '.',
+          ...(!!process.env.SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST ? {
+            transform: (content: string) => {
+              const manifest = JSON.parse(content);
+              manifest.key = extensionPublicKey;
+              return JSON.stringify(manifest, null, 2);
+            }
+          } : {})
         }
       ]
     })


### PR DESCRIPTION
The public key is hardcoded in vite.config.mts. When SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST is set, the vite build transforms the copied manifest.json to include the key field, ensuring the packed extension shares the same Chrome extension ID as the Web Store listing.

Fixes #1452