### PR TITLE
feat(extension): add focusTab option to prevent focus stealing on connect

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -26,6 +26,7 @@ type PageMessage = {
   tabId?: number;
   windowId?: number;
   mcpRelayUrl: string;
+  focusTab?: boolean;
 } | {
   type: 'getConnectionStatus';
 } | {
@@ -61,7 +62,7 @@ class TabShareExtension {
       case 'connectToTab':
         const tabId = message.tabId || sender.tab?.id!;
         const windowId = message.windowId || sender.tab?.windowId!;
-        this._connectTab(sender.tab!.id!, tabId, windowId, message.mcpRelayUrl!).then(
+        this._connectTab(sender.tab!.id!, tabId, windowId, message.mcpRelayUrl!, message.focusTab).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true; // Return true to indicate that the response will be sent asynchronously
@@ -104,7 +105,7 @@ class TabShareExtension {
     }
   }
 
-  private async _connectTab(selectorTabId: number, tabId: number, windowId: number, mcpRelayUrl: string): Promise<void> {
+  private async _connectTab(selectorTabId: number, tabId: number, windowId: number, mcpRelayUrl: string, focusTab?: boolean): Promise<void> {
     try {
       debugLog(`Connecting tab ${tabId} to relay at ${mcpRelayUrl}`);
       try {
@@ -126,11 +127,13 @@ class TabShareExtension {
         void this._setConnectedTabId(null);
       };
 
-      await Promise.all([
-        this._setConnectedTabId(tabId),
-        chrome.tabs.update(tabId, { active: true }),
-        chrome.windows.update(windowId, { focused: true }),
-      ]);
+      await this._setConnectedTabId(tabId);
+      if (focusTab !== false) {
+        await Promise.all([
+          chrome.tabs.update(tabId, { active: true }),
+          chrome.windows.update(windowId, { focused: true }),
+        ]);
+      }
       debugLog(`Connected to MCP bridge`);
     } catch (error: any) {
       await this._setConnectedTabId(null);

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -37,6 +37,7 @@ const ConnectApp: React.FC = () => {
   const [clientInfo, setClientInfo] = useState('unknown');
   const [mcpRelayUrl, setMcpRelayUrl] = useState('');
   const [newTab, setNewTab] = useState<boolean>(false);
+  const [focusTab, setFocusTab] = useState<boolean>(true);
 
   useEffect(() => {
     const runAsync = async () => {
@@ -103,6 +104,9 @@ const ConnectApp: React.FC = () => {
 
       await connectToMCPRelay(relayUrl);
 
+      if (params.get('focusTab') === 'false')
+        setFocusTab(false);
+
       // If this is a browser_navigate command, hide the tab list and show simple allow/reject
       if (params.get('newTab') === 'true') {
         setNewTab(true);
@@ -144,6 +148,7 @@ const ConnectApp: React.FC = () => {
         mcpRelayUrl,
         tabId: tab?.id,
         windowId: tab?.windowId,
+        focusTab,
       });
 
       if (response?.success) {
@@ -160,7 +165,7 @@ const ConnectApp: React.FC = () => {
         message: `MCP client "${clientInfo}" failed to connect: ${e}`
       });
     }
-  }, [clientInfo, mcpRelayUrl]);
+  }, [clientInfo, mcpRelayUrl, focusTab]);
 
   useEffect(() => {
     const listener = (message: any) => {


### PR DESCRIPTION
## Summary
- Adds a `focusTab` URL parameter to the extension connect page that controls whether connecting to a tab activates it and focuses its window.
- When `focusTab=false` is passed, the extension skips calling `chrome.tabs.update(tabId, { active: true })` and `chrome.windows.update(windowId, { focused: true })`, preventing focus from being stolen from the terminal.
- Defaults to `true` for backward compatibility.