### PR TITLE
fix(extension): support multiple tabs opened by Playwright

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -35,6 +35,7 @@ type PageMessage = {
 class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
   private _connectedTabId: number | null = null;
+  private _playwrightTabIds: Set<number> = new Set();
   private _pendingTabSelection = new Map<number, { connection: RelayConnection, timerId?: number }>();
 
   constructor() {
@@ -67,7 +68,8 @@ class TabShareExtension {
         return true; // Return true to indicate that the response will be sent asynchronously
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabId: this._connectedTabId
+          connectedTabId: this._connectedTabId,
+          playwrightTabIds: [...this._playwrightTabIds],
         });
         return false;
       case 'disconnect':
@@ -124,6 +126,17 @@ class TabShareExtension {
         debugLog('MCP connection closed');
         this._activeConnection = undefined;
         void this._setConnectedTabId(null);
+        for (const pwTabId of this._playwrightTabIds)
+          void this._updateBadge(pwTabId, { text: '' });
+        this._playwrightTabIds.clear();
+      };
+      this._activeConnection.onPlaywrightTabCreated = (pwTabId: number) => {
+        this._playwrightTabIds.add(pwTabId);
+        void this._updateBadge(pwTabId, { text: '✓', color: '#1976D2', title: 'Playwright managed tab' });
+      };
+      this._activeConnection.onPlaywrightTabRemoved = (pwTabId: number) => {
+        this._playwrightTabIds.delete(pwTabId);
+        void this._updateBadge(pwTabId, { text: '' });
       };
 
       await Promise.all([
@@ -166,6 +179,10 @@ class TabShareExtension {
       pendingConnection.close('Browser tab closed');
       return;
     }
+    if (this._playwrightTabIds.has(tabId)) {
+      this._playwrightTabIds.delete(tabId);
+      return;
+    }
     if (this._connectedTabId !== tabId)
       return;
     this._activeConnection?.close('Browser tab closed');
@@ -197,6 +214,8 @@ class TabShareExtension {
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
     if (this._connectedTabId === tabId)
       void this._setConnectedTabId(tabId);
+    if (this._playwrightTabIds.has(tabId))
+      void this._updateBadge(tabId, { text: '✓', color: '#1976D2', title: 'Playwright managed tab' });
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -16,6 +16,13 @@
 
 import { RelayConnection, debugLog } from './relayConnection';
 
+type ConnectionState = {
+  connection: RelayConnection;
+  connectedTabId: number;
+  playwrightTabIds: Set<number>;
+  mcpRelayUrl: string;
+};
+
 type PageMessage = {
   type: 'connectToMCPRelay';
   mcpRelayUrl: string;
@@ -30,13 +37,12 @@ type PageMessage = {
   type: 'getConnectionStatus';
 } | {
   type: 'disconnect';
+  mcpRelayUrl?: string;
 };
 
 class TabShareExtension {
-  private _activeConnection: RelayConnection | undefined;
-  private _connectedTabId: number | null = null;
-  private _playwrightTabIds = new Set<number>();
-  private _pendingTabSelection = new Map<number, { connection: RelayConnection, timerId?: number }>();
+  private _connections = new Map<string, ConnectionState>();
+  private _pendingTabSelection = new Map<number, { connection: RelayConnection, mcpRelayUrl: string, timerId?: number }>();
 
   constructor() {
     chrome.tabs.onRemoved.addListener(this._onTabRemoved.bind(this));
@@ -68,12 +74,18 @@ class TabShareExtension {
         return true; // Return true to indicate that the response will be sent asynchronously
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabId: this._connectedTabId,
-          playwrightTabIds: [...this._playwrightTabIds],
+          connections: [...this._connections.values()].map(s => ({
+            mcpRelayUrl: s.mcpRelayUrl,
+            connectedTabId: s.connectedTabId,
+            playwrightTabIds: [...s.playwrightTabIds],
+          })),
+          // Legacy fields for backward compat: first connection's tabId
+          connectedTabId: [...this._connections.values()][0]?.connectedTabId ?? null,
+          playwrightTabIds: [...this._connections.values()].flatMap(s => [...s.playwrightTabIds]),
         });
         return false;
       case 'disconnect':
-        this._disconnect().then(
+        this._disconnect(message.mcpRelayUrl).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true;
@@ -97,7 +109,7 @@ class TabShareExtension {
         this._pendingTabSelection.delete(selectorTabId);
         // TODO: show error in the selector tab?
       };
-      this._pendingTabSelection.set(selectorTabId, { connection });
+      this._pendingTabSelection.set(selectorTabId, { connection, mcpRelayUrl });
       debugLog(`Connected to MCP relay`);
     } catch (error: any) {
       const message = `Failed to connect to MCP relay: ${error.message}`;
@@ -109,56 +121,59 @@ class TabShareExtension {
   private async _connectTab(selectorTabId: number, tabId: number, windowId: number, mcpRelayUrl: string): Promise<void> {
     try {
       debugLog(`Connecting tab ${tabId} to relay at ${mcpRelayUrl}`);
-      try {
-        this._activeConnection?.close('Another connection is requested');
-      } catch (error: any) {
-        debugLog(`Error closing active connection:`, error);
-      }
-      await this._setConnectedTabId(null);
 
-      this._activeConnection = this._pendingTabSelection.get(selectorTabId)?.connection;
-      if (!this._activeConnection)
+      const pending = this._pendingTabSelection.get(selectorTabId);
+      if (!pending)
         throw new Error('No active MCP relay connection');
       this._pendingTabSelection.delete(selectorTabId);
 
-      this._activeConnection.setTabId(tabId);
-      this._activeConnection.onclose = () => {
-        debugLog('MCP connection closed');
-        this._activeConnection = undefined;
-        void this._setConnectedTabId(null);
-        for (const pwTabId of this._playwrightTabIds)
-          void this._updateBadge(pwTabId, { text: '' });
-        this._playwrightTabIds.clear();
+      const connection = pending.connection;
+      const relayUrl = pending.mcpRelayUrl;
+
+      // Close any existing connection on the same relay URL.
+      const existing = this._connections.get(relayUrl);
+      if (existing) {
+        existing.connection.close('Another connection is requested');
+        this._connections.delete(relayUrl);
+      }
+
+      const state: ConnectionState = {
+        connection,
+        connectedTabId: tabId,
+        playwrightTabIds: new Set(),
+        mcpRelayUrl: relayUrl,
       };
-      this._activeConnection.onPlaywrightTabCreated = (pwTabId: number) => {
-        this._playwrightTabIds.add(pwTabId);
+      this._connections.set(relayUrl, state);
+
+      connection.setTabId(tabId);
+      connection.onclose = () => {
+        debugLog('MCP connection closed');
+        if (this._connections.get(relayUrl)?.connection === connection)
+          this._connections.delete(relayUrl);
+        void this._updateBadge(state.connectedTabId, { text: '' });
+        for (const pwTabId of state.playwrightTabIds)
+          void this._updateBadge(pwTabId, { text: '' });
+        state.playwrightTabIds.clear();
+      };
+      connection.onPlaywrightTabCreated = (pwTabId: number) => {
+        state.playwrightTabIds.add(pwTabId);
         void this._updateBadge(pwTabId, { text: '✓', color: '#1976D2', title: 'Playwright managed tab' });
       };
-      this._activeConnection.onPlaywrightTabRemoved = (pwTabId: number) => {
-        this._playwrightTabIds.delete(pwTabId);
+      connection.onPlaywrightTabRemoved = (pwTabId: number) => {
+        state.playwrightTabIds.delete(pwTabId);
         void this._updateBadge(pwTabId, { text: '' });
       };
 
       await Promise.all([
-        this._setConnectedTabId(tabId),
+        this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' }),
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
       debugLog(`Connected to MCP bridge`);
     } catch (error: any) {
-      await this._setConnectedTabId(null);
       debugLog(`Failed to connect tab ${tabId}:`, error.message);
       throw error;
     }
-  }
-
-  private async _setConnectedTabId(tabId: number | null): Promise<void> {
-    const oldTabId = this._connectedTabId;
-    this._connectedTabId = tabId;
-    if (oldTabId && oldTabId !== tabId)
-      await this._updateBadge(oldTabId, { text: '' });
-    if (tabId)
-      await this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
   }
 
   private async _updateBadge(tabId: number, { text, color, title }: { text: string; color?: string, title?: string }): Promise<void> {
@@ -173,21 +188,23 @@ class TabShareExtension {
   }
 
   private async _onTabRemoved(tabId: number): Promise<void> {
-    const pendingConnection = this._pendingTabSelection.get(tabId)?.connection;
+    const pendingConnection = [...this._pendingTabSelection.entries()].find(([k]) => k === tabId)?.[1];
     if (pendingConnection) {
       this._pendingTabSelection.delete(tabId);
-      pendingConnection.close('Browser tab closed');
+      pendingConnection.connection.close('Browser tab closed');
       return;
     }
-    if (this._playwrightTabIds.has(tabId)) {
-      this._playwrightTabIds.delete(tabId);
-      return;
+    for (const [relayUrl, state] of this._connections) {
+      if (state.playwrightTabIds.has(tabId)) {
+        state.playwrightTabIds.delete(tabId);
+        return;
+      }
+      if (state.connectedTabId === tabId) {
+        state.connection.close('Browser tab closed');
+        this._connections.delete(relayUrl);
+        return;
+      }
     }
-    if (this._connectedTabId !== tabId)
-      return;
-    this._activeConnection?.close('Browser tab closed');
-    this._activeConnection = undefined;
-    this._connectedTabId = null;
   }
 
   private _onTabActivated(activeInfo: chrome.tabs.TabActiveInfo) {
@@ -212,10 +229,12 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    if (this._connectedTabId === tabId)
-      void this._setConnectedTabId(tabId);
-    if (this._playwrightTabIds.has(tabId))
-      void this._updateBadge(tabId, { text: '✓', color: '#1976D2', title: 'Playwright managed tab' });
+    for (const state of this._connections.values()) {
+      if (state.connectedTabId === tabId)
+        void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
+      if (state.playwrightTabIds.has(tabId))
+        void this._updateBadge(tabId, { text: '✓', color: '#1976D2', title: 'Playwright managed tab' });
+    }
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
@@ -230,10 +249,18 @@ class TabShareExtension {
     });
   }
 
-  private async _disconnect(): Promise<void> {
-    this._activeConnection?.close('User disconnected');
-    this._activeConnection = undefined;
-    await this._setConnectedTabId(null);
+  private async _disconnect(mcpRelayUrl?: string): Promise<void> {
+    if (mcpRelayUrl) {
+      const state = this._connections.get(mcpRelayUrl);
+      if (state) {
+        state.connection.close('User disconnected');
+        this._connections.delete(mcpRelayUrl);
+      }
+    } else {
+      for (const state of this._connections.values())
+        state.connection.close('User disconnected');
+      this._connections.clear();
+    }
   }
 }
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -35,7 +35,7 @@ type PageMessage = {
 class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
   private _connectedTabId: number | null = null;
-  private _playwrightTabIds: Set<number> = new Set();
+  private _playwrightTabIds = new Set<number>();
   private _pendingTabSelection = new Map<number, { connection: RelayConnection, timerId?: number }>();
 
   constructor() {

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -44,6 +44,7 @@ export class RelayConnection {
   private _tabPromise: Promise<void>;
   private _tabPromiseResolve!: () => void;
   private _closed = false;
+  private _playwrightTabIds: Set<number> = new Set();
 
   onclose?: () => void;
 
@@ -80,25 +81,37 @@ export class RelayConnection {
     chrome.debugger.onEvent.removeListener(this._eventListener);
     chrome.debugger.onDetach.removeListener(this._detachListener);
     chrome.debugger.detach(this._debuggee).catch(() => {});
+    for (const tabId of this._playwrightTabIds)
+      chrome.debugger.detach({ tabId }).catch(() => {});
+    this._playwrightTabIds.clear();
     this.onclose?.();
   }
 
   private _onDebuggerEvent(source: chrome.debugger.DebuggerSession, method: string, params: any): void {
-    if (source.tabId !== this._debuggee.tabId)
+    const isInitialTab = source.tabId === this._debuggee.tabId;
+    const isPlaywrightTab = source.tabId !== undefined && this._playwrightTabIds.has(source.tabId);
+    if (!isInitialTab && !isPlaywrightTab)
       return;
     debugLog('Forwarding CDP event:', method, params);
     const sessionId = source.sessionId;
+    const tabId = isPlaywrightTab ? source.tabId : undefined;
     this._sendMessage({
       method: 'forwardCDPEvent',
       params: {
         sessionId,
         method,
         params,
+        tabId,
       },
     });
   }
 
   private _onDebuggerDetach(source: chrome.debugger.Debuggee, reason: string): void {
+    if (source.tabId !== undefined && this._playwrightTabIds.has(source.tabId)) {
+      debugLog('Playwright tab detached:', source.tabId, reason);
+      this._playwrightTabIds.delete(source.tabId);
+      return;
+    }
     if (source.tabId !== this._debuggee.tabId)
       return;
     this.close(`Debugger detached: ${reason}`);
@@ -142,23 +155,40 @@ export class RelayConnection {
       const result: any = await chrome.debugger.sendCommand(this._debuggee, 'Target.getTargetInfo');
       return {
         targetInfo: result?.targetInfo,
+        tabId: this._debuggee.tabId,
       };
+    }
+    if (message.method === 'createTab') {
+      const url: string = message.params?.url || 'about:blank';
+      debugLog('Creating new tab:', url);
+      const tab = await chrome.tabs.create({ url, active: true });
+      const tabId = tab.id!;
+      // Wait briefly for the tab to load enough for the debugger to attach
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await chrome.debugger.attach({ tabId }, '1.3');
+      const result: any = await chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo');
+      const targetInfo = result?.targetInfo || {
+        targetId: String(tabId),
+        type: 'page',
+        title: '',
+        url: tab.url || url,
+        attached: false,
+        canAccessOpener: false,
+      };
+      this._playwrightTabIds.add(tabId);
+      debugLog('Created playwright tab:', tabId, targetInfo);
+      return { tabId, targetInfo };
     }
     if (!this._debuggee.tabId)
       throw new Error('No tab is connected. Please go to the Playwright MCP extension and select the tab you want to connect to.');
     if (message.method === 'forwardCDPCommand') {
-      const { sessionId, method, params } = message.params;
-      debugLog('CDP command:', method, params);
-      const debuggerSession: chrome.debugger.DebuggerSession = {
-        ...this._debuggee,
-        sessionId,
-      };
+      const { sessionId, method, params, tabId } = message.params;
+      debugLog('CDP command:', method, params, 'tabId:', tabId);
+      const debuggee: chrome.debugger.DebuggerSession = tabId !== undefined
+        ? { tabId, sessionId }
+        : { ...this._debuggee, sessionId };
       // Forward CDP command to chrome.debugger
-      return await chrome.debugger.sendCommand(
-          debuggerSession,
-          method,
-          params
-      );
+      return await chrome.debugger.sendCommand(debuggee, method, params);
     }
   }
 

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -44,7 +44,7 @@ export class RelayConnection {
   private _tabPromise: Promise<void>;
   private _tabPromiseResolve!: () => void;
   private _closed = false;
-  private _playwrightTabIds: Set<number> = new Set();
+  private _playwrightTabIds = new Set<number>();
 
   onclose?: () => void;
   onPlaywrightTabCreated?: (tabId: number) => void;
@@ -162,7 +162,7 @@ export class RelayConnection {
       };
     }
     if (message.method === 'createTab') {
-      const url: string = message.params?.url || 'about:blank';
+      const url = message.params?.url ?? 'about:blank';
       debugLog('Creating new tab:', url);
       const tab = await chrome.tabs.create({ url, active: true });
       const tabId = tab.id!;
@@ -189,9 +189,8 @@ export class RelayConnection {
       const { sessionId, method, params, tabId } = message.params;
       debugLog('CDP command:', method, params, 'tabId:', tabId);
       const debuggee: chrome.debugger.DebuggerSession = tabId !== undefined
-        ? { tabId, sessionId }
-        : { ...this._debuggee, sessionId };
-      // Forward CDP command to chrome.debugger
+          ? { tabId, sessionId }
+          : { ...this._debuggee, sessionId };
       return await chrome.debugger.sendCommand(debuggee, method, params);
     }
   }

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -47,6 +47,8 @@ export class RelayConnection {
   private _playwrightTabIds: Set<number> = new Set();
 
   onclose?: () => void;
+  onPlaywrightTabCreated?: (tabId: number) => void;
+  onPlaywrightTabRemoved?: (tabId: number) => void;
 
   constructor(ws: WebSocket) {
     this._debuggee = { };
@@ -110,6 +112,7 @@ export class RelayConnection {
     if (source.tabId !== undefined && this._playwrightTabIds.has(source.tabId)) {
       debugLog('Playwright tab detached:', source.tabId, reason);
       this._playwrightTabIds.delete(source.tabId);
+      this.onPlaywrightTabRemoved?.(source.tabId);
       return;
     }
     if (source.tabId !== this._debuggee.tabId)
@@ -176,6 +179,7 @@ export class RelayConnection {
         canAccessOpener: false,
       };
       this._playwrightTabIds.add(tabId);
+      this.onPlaywrightTabCreated?.(tabId);
       debugLog('Created playwright tab:', tabId, targetInfo);
       return { tabId, targetInfo };
     }

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -25,12 +25,14 @@ interface ConnectionStatus {
   isConnected: boolean;
   connectedTabId: number | null;
   connectedTab?: TabInfo;
+  playwrightTabs: TabInfo[];
 }
 
 const StatusApp: React.FC = () => {
   const [status, setStatus] = useState<ConnectionStatus>({
     isConnected: false,
-    connectedTabId: null
+    connectedTabId: null,
+    playwrightTabs: [],
   });
 
   useEffect(() => {
@@ -38,33 +40,30 @@ const StatusApp: React.FC = () => {
   }, []);
 
   const loadStatus = async () => {
-    // Get current connection status from background script
-    const { connectedTabId } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
-    if (connectedTabId) {
-      const tab = await chrome.tabs.get(connectedTabId);
-      setStatus({
-        isConnected: true,
-        connectedTabId,
-        connectedTab: {
-          id: tab.id!,
-          windowId: tab.windowId!,
-          title: tab.title!,
-          url: tab.url!,
-          favIconUrl: tab.favIconUrl
-        }
-      });
-    } else {
-      setStatus({
-        isConnected: false,
-        connectedTabId: null
-      });
-    }
+    const { connectedTabId, playwrightTabIds = [] } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+
+    const fetchTab = async (id: number): Promise<TabInfo | null> => {
+      try {
+        const tab = await chrome.tabs.get(id);
+        return { id: tab.id!, windowId: tab.windowId!, title: tab.title!, url: tab.url!, favIconUrl: tab.favIconUrl };
+      } catch {
+        return null;
+      }
+    };
+
+    const connectedTab = connectedTabId ? await fetchTab(connectedTabId) ?? undefined : undefined;
+    const playwrightTabs = (await Promise.all((playwrightTabIds as number[]).map(fetchTab))).filter((t): t is TabInfo => t !== null);
+
+    setStatus({
+      isConnected: !!connectedTabId,
+      connectedTabId,
+      connectedTab,
+      playwrightTabs,
+    });
   };
 
-  const openConnectedTab = async () => {
-    if (!status.connectedTabId)
-      return;
-    await chrome.tabs.update(status.connectedTabId, { active: true });
+  const openTab = async (tabId: number) => {
+    await chrome.tabs.update(tabId, { active: true });
     window.close();
   };
 
@@ -89,13 +88,29 @@ const StatusApp: React.FC = () => {
                     Disconnect
                   </Button>
                 }
-                onClick={openConnectedTab}
+                onClick={() => openTab(status.connectedTabId!)}
               />
             </div>
           </div>
         ) : (
           <div className='status-banner'>
             No MCP clients are currently connected.
+          </div>
+        )}
+        {status.playwrightTabs.length > 0 && (
+          <div>
+            <div className='tab-section-title'>
+              Playwright managed tabs:
+            </div>
+            <div>
+              {status.playwrightTabs.map(tab => (
+                <TabItem
+                  key={tab.id}
+                  tab={tab}
+                  onClick={() => openTab(tab.id)}
+                />
+              ))}
+            </div>
           </div>
         )}
         <AuthTokenSection />

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Button, TabItem  } from './tabItem';
+import { Button, TabItem } from './tabItem';
 
 import type { TabInfo } from './tabItem';
 import { AuthTokenSection } from './authToken';

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -21,26 +21,23 @@ import { Button, TabItem } from './tabItem';
 import type { TabInfo } from './tabItem';
 import { AuthTokenSection } from './authToken';
 
-interface ConnectionStatus {
-  isConnected: boolean;
-  connectedTabId: number | null;
+type ConnectionInfo = {
+  mcpRelayUrl: string;
+  connectedTabId: number;
+  playwrightTabIds: number[];
   connectedTab?: TabInfo;
   playwrightTabs: TabInfo[];
-}
+};
 
 const StatusApp: React.FC = () => {
-  const [status, setStatus] = useState<ConnectionStatus>({
-    isConnected: false,
-    connectedTabId: null,
-    playwrightTabs: [],
-  });
+  const [connections, setConnections] = useState<ConnectionInfo[]>([]);
 
   useEffect(() => {
     void loadStatus();
   }, []);
 
   const loadStatus = async () => {
-    const { connectedTabId, playwrightTabIds = [] } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+    const { connections: rawConnections = [] } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
 
     const fetchTab = async (id: number): Promise<TabInfo | null> => {
       try {
@@ -51,15 +48,14 @@ const StatusApp: React.FC = () => {
       }
     };
 
-    const connectedTab = connectedTabId ? await fetchTab(connectedTabId) ?? undefined : undefined;
-    const playwrightTabs = (await Promise.all((playwrightTabIds as number[]).map(fetchTab))).filter((t): t is TabInfo => t !== null);
-
-    setStatus({
-      isConnected: !!connectedTabId,
-      connectedTabId,
-      connectedTab,
-      playwrightTabs,
-    });
+    const resolved: ConnectionInfo[] = await Promise.all(
+        rawConnections.map(async (c: { mcpRelayUrl: string, connectedTabId: number, playwrightTabIds: number[] }) => {
+          const connectedTab = await fetchTab(c.connectedTabId) ?? undefined;
+          const playwrightTabs = (await Promise.all(c.playwrightTabIds.map(fetchTab))).filter((t): t is TabInfo => t !== null);
+          return { ...c, connectedTab, playwrightTabs };
+        })
+    );
+    setConnections(resolved);
   };
 
   const openTab = async (tabId: number) => {
@@ -67,52 +63,57 @@ const StatusApp: React.FC = () => {
     window.close();
   };
 
-  const disconnect = async () => {
-    await chrome.runtime.sendMessage({ type: 'disconnect' });
-    window.close();
+  const disconnect = async (mcpRelayUrl: string) => {
+    await chrome.runtime.sendMessage({ type: 'disconnect', mcpRelayUrl });
+    void loadStatus();
   };
 
   return (
     <div className='app-container'>
       <div className='content-wrapper'>
-        {status.isConnected && status.connectedTab ? (
-          <div>
-            <div className='tab-section-title'>
-              Page with connected MCP client:
-            </div>
-            <div>
-              <TabItem
-                tab={status.connectedTab}
-                button={
-                  <Button variant='primary' onClick={disconnect}>
-                    Disconnect
-                  </Button>
-                }
-                onClick={() => openTab(status.connectedTabId!)}
-              />
-            </div>
-          </div>
-        ) : (
+        {connections.length === 0 ? (
           <div className='status-banner'>
             No MCP clients are currently connected.
           </div>
-        )}
-        {status.playwrightTabs.length > 0 && (
-          <div>
-            <div className='tab-section-title'>
-              Playwright managed tabs:
-            </div>
-            <div>
-              {status.playwrightTabs.map(tab => (
+        ) : connections.map((c, i) => (
+          <div key={c.mcpRelayUrl}>
+            {connections.length > 1 && (
+              <div className='tab-section-title'>
+                Instance {i + 1}:
+              </div>
+            )}
+            {c.connectedTab && (
+              <div>
+                <div className='tab-section-title'>
+                  Page with connected MCP client:
+                </div>
                 <TabItem
-                  key={tab.id}
-                  tab={tab}
-                  onClick={() => openTab(tab.id)}
+                  tab={c.connectedTab}
+                  button={
+                    <Button variant='primary' onClick={() => disconnect(c.mcpRelayUrl)}>
+                      Disconnect
+                    </Button>
+                  }
+                  onClick={() => openTab(c.connectedTabId)}
                 />
-              ))}
-            </div>
+              </div>
+            )}
+            {c.playwrightTabs.length > 0 && (
+              <div>
+                <div className='tab-section-title'>
+                  Playwright managed tabs:
+                </div>
+                {c.playwrightTabs.map(tab => (
+                  <TabItem
+                    key={tab.id}
+                    tab={tab}
+                    onClick={() => openTab(tab.id)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
-        )}
+        ))}
         <AuthTokenSection />
       </div>
     </div>


### PR DESCRIPTION
Fixes #1317

## Problem

When using \`--extension\` mode, Playwright can only control the single tab that was manually selected in the extension popup. Any tab Playwright opens via \`tab-new\` (i.e. \`Target.createTarget\`) is created but immediately uncontrollable.

**Root cause:** \`_onDebuggerEvent\` in \`RelayConnection\` only forwards CDP events where \`source.tabId === this._debuggee.tabId\`. New tabs never have a debugger attached and their events are never forwarded — so Playwright sees them in \`tab-list\` but cannot interact with them.

## Fix

### \`relayConnection.ts\`
- Add \`createTab\` command: creates a Chrome tab via \`chrome.tabs.create()\`, attaches the debugger, and returns \`{ tabId, targetInfo }\` to the relay
- Track Playwright-opened tabs in \`_playwrightTabIds: Set<number>\`
- Forward CDP events from all Playwright-opened tabs (tagged with \`tabId\` for relay routing)
- Route \`forwardCDPCommand\` to the correct debuggee by \`tabId\`
- \`attachToTab\` now returns \`tabId\` so the relay can build its session→tab mapping
- Add \`onPlaywrightTabCreated\` / \`onPlaywrightTabRemoved\` callbacks for the background script
- Detach debugger from all Playwright tabs on close

### \`background.ts\`
- Replace single \`_activeConnection\` with \`_connections: Map<mcpRelayUrl, ConnectionState>\` — each relay URL (UUID-based) gets fully isolated state
- Multiple simultaneous MCP instances no longer conflict in the extension
- Track Playwright tab IDs per connection; clear badges and the set when the connection closes
- Show a blue \`✓\` badge on Playwright-managed tabs (distinct from the green \`✓\` on the initial connected tab)
- Expose \`playwrightTabIds\` via \`getConnectionStatus\`
- Clean up Playwright tab IDs in \`_onTabRemoved\`

### \`status.tsx\`
- Show all active connections, each with their own Playwright-managed tab list
- Add a "Playwright managed tabs" section per connection, clickable to focus

## Multi-client architecture

With \`--port\` (HTTP mode), a single playwright-mcp process handles multiple clients via HTTP Streamable (\`POST /mcp\`) or SSE (\`GET /sse\`). Each MCP session calls \`createExtensionBrowser()\`, which creates a new \`CDPRelayServer\` with a unique UUID relay URL.

Before this PR, the extension only tracked one relay connection — the second client would be rejected. The multi-instance fix in \`background.ts\` makes the extension handle each relay URL independently:

\`\`\`
playwright-mcp --extension --port 4321   (one shared process)
  ├── Claude session A  →  CDPRelayServer (uuid-aaa)  →  extension ConnectionState A  →  Tab 1
  └── Claude session B  →  CDPRelayServer (uuid-bbb)  →  extension ConnectionState B  →  Tab 2
\`\`\`

Each session needs its own browser tab (Chrome only allows one debugger per tab). As long as each client connects to a different tab, they are fully isolated with no conflicts.

The companion relay-server changes (protocol + \`cdpRelay.ts\`) are in microsoft/playwright#39805.