### PR TITLE
docs(mcp): fix persistent profile directory name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,14 +413,16 @@ Persistent profile is located at the following locations and you can override it
 
 ```bash
 # Windows
-%USERPROFILE%\AppData\Local\ms-playwright\mcp-{channel}-profile
+%USERPROFILE%\AppData\Local\ms-playwright\mcp-{channel}-{workspace-hash}
 
 # macOS
-- ~/Library/Caches/ms-playwright/mcp-{channel}-profile
+- ~/Library/Caches/ms-playwright/mcp-{channel}-{workspace-hash}
 
 # Linux
-- ~/.cache/ms-playwright/mcp-{channel}-profile
+- ~/.cache/ms-playwright/mcp-{channel}-{workspace-hash}
 ```
+
+`{workspace-hash}` is derived from the MCP client's workspace root, so different projects get separate profiles automatically.
 
 **Isolated**
 


### PR DESCRIPTION
## Summary
- README says persistent profile directory is `mcp-{channel}-profile`, but code generates `mcp-{channel}-{hash}` where `{hash}` is a 7-char SHA-256 of the working directory
- Updated the User profile section in README.md to reflect the actual directory naming scheme and explain what `{hash}` means

Made with [Cursor](https://cursor.com)