### PR TITLE
feat(mcp): add $schema reference in README and sync schema in roll.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,17 @@ using the `--config` command line option:
 npx @playwright/mcp@latest --config path/to/config.json
 ```
 
+Add `$schema` to your config file for IDE autocompletion and validation:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/playwright/main/packages/playwright-core/src/tools/mcp/mcp-config.schema.json",
+  "browser": {
+    "browserName": "chromium"
+  }
+}
+```
+
 <details>
 <summary>Configuration file schema</summary>
 

--- a/roll.js
+++ b/roll.js
@@ -3,15 +3,23 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 function copyConfig() {
-  const src = path.join(__dirname, '..', 'playwright', 'packages', 'playwright-core', 'src', 'tools', 'mcp', 'config.d.ts');
-  const dst = path.join(__dirname, 'packages', 'playwright-mcp', 'config.d.ts');
-  let content = fs.readFileSync(src, 'utf-8');
+  const mcpDir = path.join(__dirname, '..', 'playwright', 'packages', 'playwright-core', 'src', 'tools', 'mcp');
+  const dstDir = path.join(__dirname, 'packages', 'playwright-mcp');
+
+  const configSrc = path.join(mcpDir, 'config.d.ts');
+  let content = fs.readFileSync(configSrc, 'utf-8');
   content = content.replace(
     "import type * as playwright from 'playwright-core';",
     "import type * as playwright from 'playwright';"
   );
-  fs.writeFileSync(dst, content);
-  console.log(`Copied config.d.ts from ${src} to ${dst}`);
+  fs.writeFileSync(path.join(dstDir, 'config.d.ts'), content);
+  console.log(`Copied config.d.ts`);
+
+  const schemaSrc = path.join(mcpDir, 'mcp-config.schema.json');
+  if (fs.existsSync(schemaSrc)) {
+    fs.copyFileSync(schemaSrc, path.join(dstDir, 'mcp-config.schema.json'));
+    console.log(`Copied mcp-config.schema.json`);
+  }
 }
 
 function updatePlaywrightVersion(version) {


### PR DESCRIPTION
## Summary

- Add `$schema` example to the Configuration file section in README
- Extend `roll.js` `copyConfig()` to also copy `mcp-config.schema.json` from `playwright-core`, so the schema ships with the `@playwright/mcp` npm package

Depends on https://github.com/microsoft/playwright/pull/40025 (the schema generator and output file).