### PR TITLE
Add Codex plugin quality gate CI

### DIFF
--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high


### PR DESCRIPTION
Adds a CI workflow to validate Codex plugin manifests using the HOL Codex Plugin Scanner.

This workflow runs on any PR modifying plugin files and ensures manifest structure, skills, and MCP config are valid with a minimum quality score of 80/100.

Scanner: codex-plugin-scanner | awesome-codex-plugins