### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -1,0 +1,32 @@
+name: Validate Skill
+
+on:
+  pull_request:
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  push:
+    branches:
+      - main
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate skill definition
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Validate skill
+        uses: hashgraph-online/skill-publish@v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
Playwright MCP server for browser automation.

- Provides Playwright tools for AI agents to control Chromium, Firefox, and WebKit
- Supports stdio and streamable HTTP transports

This PR adds a validate-only workflow that checks SKILL.md and skill.json against HOL schema. It does not modify runtime code.

Let me know if you'd prefer a different workflow path or skill directory.