### PR TITLE
test(extension): properly delete env vars in fixture cleanup

### DIFF
--- a/packages/extension/tests/extension.spec.ts
+++ b/packages/extension/tests/extension.spec.ts
@@ -100,14 +100,14 @@ const test = base.extend<TestFixtures>({
     await use((timeoutMs: number) => {
       process.env.PWMCP_TEST_CONNECTION_TIMEOUT = timeoutMs.toString();
     });
-    process.env.PWMCP_TEST_CONNECTION_TIMEOUT = undefined;
+    delete process.env.PWMCP_TEST_CONNECTION_TIMEOUT;
   },
 
   overrideProtocolVersion: async ({}, use) => {
     await use((version: number) => {
       process.env.PWMCP_TEST_PROTOCOL_VERSION = version.toString();
     });
-    process.env.PWMCP_TEST_PROTOCOL_VERSION = undefined;
+    delete process.env.PWMCP_TEST_PROTOCOL_VERSION;
   },
 
   cli: async ({ mcpBrowser }, use, testInfo) => {


### PR DESCRIPTION
## Summary
Assigning \`undefined\` to a \`process.env\` property coerces it to the string \`"undefined"\` rather than removing the variable. The string then leaks into subsequent tests' MCP child processes, where the truthy check passes and \`parseInt("undefined")\` yields \`NaN\`, causing the extension connection timeout in `cdpRelay.ts` to fire immediately.

This caused `bypass connection dialog with token` to fail (and leave an orphaned Chrome process showing the safe-storage prompt) when run after `custom executablePath` under `--workers 1`.

Use `delete` to actually remove the variables in the `useShortConnectionTimeout` and `overrideProtocolVersion` fixture cleanups.