### PR TITLE
feat(extension): support multiple tabs over a single connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,18 @@ jobs:
       if: matrix.os == 'macos-15'
       run: npm run test --workspace=packages/extension
       continue-on-error: true
+    - name: Install extension protocol v1 compat deps
+      if: matrix.os == 'macos-15'
+      run: npm ci
+      working-directory: ./packages/extension/protocol-v1-compat
+    - name: Run extension protocol v1 compat tests
+      id: test-extension-v1-compat
+      if: matrix.os == 'macos-15'
+      run: npm test
+      working-directory: ./packages/extension/protocol-v1-compat
+      continue-on-error: true
     - name: Check test results
-      if: steps.test-mcp.outcome == 'failure' || steps.test-extension.outcome == 'failure'
+      if: steps.test-mcp.outcome == 'failure' || steps.test-extension.outcome == 'failure' || steps.test-extension-v1-compat.outcome == 'failure'
       run: exit 1
 
   test_mcp_docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       if: matrix.os == 'macos-15'
       run: npm ci
       working-directory: ./packages/extension/protocol-v1-compat
+    - name: Install browser for protocol v1 compat deps
+      run: npx playwright install --with-deps chromium
+      working-directory: ./packages/extension/protocol-v1-compat
     - name: Run extension protocol v1 compat tests
       id: test-extension-v1-compat
       if: matrix.os == 'macos-15'

--- a/README.md
+++ b/README.md
@@ -994,6 +994,7 @@ http.createServer(async (req, res) => {
   - Description: Capture accessibility snapshot of the current page, this is better than screenshot
   - Parameters:
     - `filename` (string, optional): Save snapshot to markdown file instead of returning it in the response.
+    - `ref` (string, optional): Element reference from the previous page snapshot to capture a partial snapshot instead of the whole page
     - `selector` (string, optional): Element selector of the root element to capture a partial snapshot instead of the whole page
     - `depth` (number, optional): Limit the depth of the snapshot tree
   - Read-only: **true**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
-        "@playwright/test": "1.60.0-alpha-1775258971000",
+        "@playwright/test": "1.60.0-alpha-1775674864000",
         "@types/node": "^24.3.0"
       }
     },
@@ -854,13 +854,13 @@
       "link": true
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-1775258971000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1775258971000.tgz",
-      "integrity": "sha512-6ZvWKDxCRxSNWtqcXdjjUfdiFkPXWb+q1EgfiG5JL5Hmpz1klCSfFgqssSpjOsZdjVlFTkPBruxClEaKCL3lgw==",
+      "version": "1.60.0-alpha-1775674864000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1775674864000.tgz",
+      "integrity": "sha512-d33bM6qU99Y6gs/aCf4YxTx1MMKxgfFN8IFbyoPi92s+cp60k/BpTQNGeDZEgMGAiqMpewqwwfZTTYYddJYLNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1775258971000"
+        "playwright": "1.60.0-alpha-1775674864000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2624,12 +2624,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1775258971000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1775258971000.tgz",
-      "integrity": "sha512-xaS8b8clhxs1uLiBQFdrKYPAxZPI1eZDshsK9LMvMyuNkwiFlK0FxWNWj01kA/dUf5/hm26xarLiM/Ah1DugyA==",
+      "version": "1.60.0-alpha-1775674864000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1775674864000.tgz",
+      "integrity": "sha512-BZ3RoIWELqtJghBvE3lPmzgWXKUgng9lfsBFnUxW8mC9ren/Xi+xPkjW7kk/XZOGsEn7yWoqNyz7oxAnS4yXDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1775258971000"
+        "playwright-core": "1.60.0-alpha-1775674864000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2646,9 +2646,9 @@
       "link": true
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1775258971000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1775258971000.tgz",
-      "integrity": "sha512-SJ5hXQUf50wA/wI1Z9xkFoJq7IwLhfX4o7hXZJExxtGo3U8UQsS3AtD1TVWkO0KTeMdFnaQ8XE4BMa5wziegnw==",
+      "version": "1.60.0-alpha-1775674864000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1775674864000.tgz",
+      "integrity": "sha512-e7dNSESddnl3len2eRvszdtUYj5WsUCGQ8EZSJG1I0vflXtE+50B4BWXur75xnWt5hQ7YBE+5wJiQBKUaHekcw==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3444,8 +3444,8 @@
       "version": "0.0.70",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1775258971000",
-        "playwright-core": "1.60.0-alpha-1775258971000"
+        "playwright": "1.60.0-alpha-1775674864000",
+        "playwright-core": "1.60.0-alpha-1775674864000"
       },
       "bin": {
         "playwright-mcp": "cli.js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "@playwright/test": "1.60.0-alpha-1775258971000",
+    "@playwright/test": "1.60.0-alpha-1775674864000",
     "@types/node": "^24.3.0"
   }
 }

--- a/packages/extension/protocol-v1-compat/package-lock.json
+++ b/packages/extension/protocol-v1-compat/package-lock.json
@@ -12,7 +12,57 @@
         "@playwright/test": "^1.59.1"
       },
       "devDependencies": {
+        "@playwright/cli": "0.1.6",
         "@playwright/mcp": "0.0.70"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.6.tgz",
+      "integrity": "sha512-6iY+826o8lvUK/ZPSRvUFDwQo2nSUa5dl9vOqK80ifPwrts3P3qzzc9X134mpO5xaQjaAkQPKoKJBV+eIWL5QQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "playwright": "1.60.0-alpha-1775584683000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/cli/node_modules/playwright": {
+      "version": "1.60.0-alpha-1775584683000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1775584683000.tgz",
+      "integrity": "sha512-LHCXlaF0ccE+Z/ergBQaW6NbX9Iq4vM8v4Bi8HjLhO7ThmiyALYZfc6yr3iDDQ5XOan5LtDMT7W6H+k3zVqt8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-1775584683000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/cli/node_modules/playwright-core": {
+      "version": "1.60.0-alpha-1775584683000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1775584683000.tgz",
+      "integrity": "sha512-ufL1tdjK+2pyt5Jqft71MJmyixa0GMWd6dlHsQKxImD9XrJrFUvOC4jr4ISSYwgl66E37pBM89LxjGEgSaRcjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -92,6 +142,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/playwright": {

--- a/packages/extension/protocol-v1-compat/package-lock.json
+++ b/packages/extension/protocol-v1-compat/package-lock.json
@@ -1,0 +1,130 @@
+{
+  "name": "protocol-v1-compat",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "protocol-v1-compat",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@playwright/test": "^1.59.1"
+      },
+      "devDependencies": {
+        "@playwright/mcp": "0.0.70"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.70.tgz",
+      "integrity": "sha512-Kl0a6l9VL8rvT1oBou3hS5yArjwWV9UlwAkq+0skfK1YVg8XfmmNaAmwZhMeNx/ZhGiWXfCllo6rD/jvZz+WuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0-alpha-1774999321000",
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-Bd5DkzYKG+2g1jLO6NeTXmGLbBYSFffJIOsR4l4hUBkJvzvGGdLZ7jZb2tOtb0WIoWXQKdQj3Ap6WthV4DBS8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-ams3Zo4VXxeOg5ZTTh16GkE8g48Bmxo/9pg9gXl9SVKlVohCU7Jaog7XntY8yFuzENA6dJc1Fz7Z/NNTm9nGEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/packages/extension/protocol-v1-compat/package.json
+++ b/packages/extension/protocol-v1-compat/package.json
@@ -19,7 +19,8 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/mcp": "0.0.70"
+    "@playwright/mcp": "0.0.70",
+    "@playwright/cli": "0.1.6"
   },
   "dependencies": {
     "@playwright/test": "^1.59.1"

--- a/packages/extension/protocol-v1-compat/package.json
+++ b/packages/extension/protocol-v1-compat/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "protocol-v1-compat",
+  "version": "0.0.0",
+  "description": "Playwright MCP Browser Extension",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/playwright-mcp.git"
+  },
+  "homepage": "https://playwright.dev",
+  "engines": {
+    "node": ">=18"
+  },
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/mcp": "0.0.70"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/packages/extension/protocol-v1-compat/playwright.config.ts
+++ b/packages/extension/protocol-v1-compat/playwright.config.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from '@playwright/test';
+
+import type { TestOptions } from './tests/fixtures';
+
+export default defineConfig<TestOptions>({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  projects: [
+    { name: 'chromium', use: { mcpBrowser: 'chromium' } },
+  ],
+});

--- a/packages/extension/protocol-v1-compat/tests/extension.spec.ts
+++ b/packages/extension/protocol-v1-compat/tests/extension.spec.ts
@@ -16,7 +16,6 @@
 
 import fs from 'fs/promises';
 import fsSync from 'fs';
-import os from 'os';
 import path from 'path';
 import { chromium } from 'playwright';
 import { spawn } from 'child_process';
@@ -102,14 +101,14 @@ const test = base.extend<TestFixtures>({
     await use((timeoutMs: number) => {
       process.env.PWMCP_TEST_CONNECTION_TIMEOUT = timeoutMs.toString();
     });
-    process.env.PWMCP_TEST_CONNECTION_TIMEOUT = undefined;
+    delete process.env.PWMCP_TEST_CONNECTION_TIMEOUT;
   },
 
   overrideProtocolVersion: async ({}, use) => {
     await use((version: number) => {
       process.env.PWMCP_TEST_PROTOCOL_VERSION = version.toString();
     });
-    process.env.PWMCP_TEST_PROTOCOL_VERSION = undefined;
+    delete process.env.PWMCP_TEST_PROTOCOL_VERSION;
   },
 
   cli: async ({ mcpBrowser }, use, testInfo) => {
@@ -126,11 +125,14 @@ const test = base.extend<TestFixtures>({
 });
 
 function cliEnv() {
-  const shortTmp = fsSync.mkdtempSync(path.join(os.tmpdir(), 'pw-mcp-v1-compat-'));
+  // sun_path on macOS is limited to ~104 chars, so the sockets dir must stay
+  // very short. os.tmpdir() resolves to /var/folders/.../T on macOS which is
+  // already 51 chars; use /tmp directly with a tiny prefix instead.
+  const shortTmp = fsSync.mkdtempSync('/tmp/pw-');
   return {
     PLAYWRIGHT_SERVER_REGISTRY: test.info().outputPath('registry'),
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
-    PLAYWRIGHT_SOCKETS_DIR: path.join(shortTmp, 'ds', String(test.info().parallelIndex)),
+    PLAYWRIGHT_SOCKETS_DIR: path.join(shortTmp, String(test.info().parallelIndex)),
   };
 }
 
@@ -226,145 +228,6 @@ test(`navigate with extension`, async ({ browserWithExtension, startClient, serv
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
-  });
-});
-
-test(`browser_tabs new creates a new tab`, async ({ browserWithExtension, startClient, server }) => {
-  server.setContent('/second.html', '<title>Second</title><body>Second page<body>', 'text/html');
-  const browserContext = await browserWithExtension.launch();
-
-  const client = await startWithExtensionFlag(browserWithExtension, startClient);
-
-  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
-    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
-  });
-
-  const navigateResponse = client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
-  });
-
-  const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
-
-  expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
-  });
-
-  // Now create a new tab via browser_tabs tool.
-  const newTabResponse = await client.callTool({
-    name: 'browser_tabs',
-    arguments: { action: 'new', url: server.PREFIX + 'second.html' },
-  });
-
-  expect(newTabResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Second page`),
-  });
-
-  // Verify we have two tabs by listing.
-  const listResponse = await client.callTool({
-    name: 'browser_tabs',
-    arguments: { action: 'list' },
-  });
-
-  expect(listResponse).toHaveResponse({
-    result: expect.stringMatching(/- 0: \[Title\]\(.*\/hello-world\)\n- 1: \(current\) \[Second\]\(.*\/second\.html\)/),
-  });
-});
-
-test(`cmd+click opens new tab visible in tab list`, async ({ browserWithExtension, startClient, server }) => {
-  server.setContent('/link-page', '<title>LinkPage</title><body><a href="/target-page">click me</a></body>', 'text/html');
-  server.setContent('/target-page', '<title>TargetPage</title><body>Target content</body>', 'text/html');
-  const browserContext = await browserWithExtension.launch();
-
-  const client = await startWithExtensionFlag(browserWithExtension, startClient);
-
-  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
-    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
-  });
-
-  const navigateResponse = client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX + 'link-page' },
-  });
-
-  const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
-
-  expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`click me`),
-  });
-
-  // Cmd+click (Meta+click) to open link in a new tab.
-  await client.callTool({
-    name: 'browser_click',
-    arguments: { element: 'click me', ref: 'e2', modifiers: ['Meta'] },
-  });
-
-  // Wait for the new tab to appear in the list.
-  await expect.poll(async () => {
-    const listResponse = await client.callTool({
-      name: 'browser_tabs',
-      arguments: { action: 'list' },
-    });
-    return (listResponse as any).content?.[0]?.text ?? '';
-  }).toContain('TargetPage');
-
-  const listResponse = await client.callTool({
-    name: 'browser_tabs',
-    arguments: { action: 'list' },
-  });
-
-  expect(listResponse).toHaveResponse({
-    result: expect.stringMatching(/- 0:.*\[LinkPage\].*\n- 1:.*\[TargetPage\]/),
-  });
-});
-
-test(`window.open from tracked tab auto-attaches new tab`, async ({ browserWithExtension, startClient, server }) => {
-  server.setContent('/opener-page', `<title>Opener</title><body><button onclick="window.open('${server.PREFIX}opened-page', '_blank', 'noopener')">open</button></body>`, 'text/html');
-  server.setContent('/opened-page', '<title>Opened</title><body>Opened content</body>', 'text/html');
-  const browserContext = await browserWithExtension.launch();
-
-  const client = await startWithExtensionFlag(browserWithExtension, startClient);
-
-  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
-    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
-  });
-
-  const navigateResponse = client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX + 'opener-page' },
-  });
-
-  const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
-
-  expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining('open'),
-  });
-
-  // Click the button that calls window.open.
-  await client.callTool({
-    name: 'browser_click',
-    arguments: { element: 'open', ref: 'e2' },
-  });
-
-  // Wait for the new tab to appear in the list.
-  await expect.poll(async () => {
-    const listResponse = await client.callTool({
-      name: 'browser_tabs',
-      arguments: { action: 'list' },
-    });
-    return (listResponse as any).content?.[0]?.text ?? '';
-  }).toContain('Opened');
-
-  const listResponse = await client.callTool({
-    name: 'browser_tabs',
-    arguments: { action: 'list' },
-  });
-
-  expect(listResponse).toHaveResponse({
-    result: expect.stringMatching(/- 0:.*\[Opener\].*\n- 1:.*\[Opened\]/),
   });
 });
 

--- a/packages/extension/protocol-v1-compat/tests/extension.spec.ts
+++ b/packages/extension/protocol-v1-compat/tests/extension.spec.ts
@@ -1,0 +1,669 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { chromium } from 'playwright';
+import { spawn } from 'child_process';
+import { test as base, expect } from './fixtures';
+
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { BrowserContext } from 'playwright';
+import type { StartClient } from './fixtures';
+
+type BrowserWithExtension = {
+  userDataDir: string;
+  launch: (mode?: 'disable-extension') => Promise<BrowserContext>;
+};
+
+type CliResult = {
+  output: string;
+  error: string;
+};
+
+type TestFixtures = {
+  browserWithExtension: BrowserWithExtension,
+  pathToExtension: string,
+  useShortConnectionTimeout: (timeoutMs: number) => void
+  overrideProtocolVersion: (version: number) => void
+  cli: (...args: string[]) => Promise<CliResult>;
+};
+
+const extensionPublicKey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB';
+const extensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
+
+const test = base.extend<TestFixtures>({
+  pathToExtension: async ({}, use, testInfo) => {
+    const extensionDir = testInfo.outputPath('extension');
+    const srcDir = path.resolve(__dirname, '../../dist');
+    await fs.cp(srcDir, extensionDir, { recursive: true });
+    const manifestPath = path.join(extensionDir, 'manifest.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    // We don't hardcode the key in manifest, but for the tests we set the key field
+    // to ensure that locally installed extension has the same id as the one published
+    // in the store.
+    manifest.key = extensionPublicKey;
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+    console.log(`Extension path: ${extensionDir}`);
+    await use(extensionDir);
+  },
+
+  browserWithExtension: async ({ mcpBrowser, pathToExtension }, use, testInfo) => {
+    // The flags no longer work in Chrome since
+    // https://chromium.googlesource.com/chromium/src/+/290ed8046692651ce76088914750cb659b65fb17%5E%21/chrome/browser/extensions/extension_service.cc?pli=1#
+    test.skip('chromium' !== mcpBrowser, '--load-extension is not supported for official builds of Chromium');
+
+    let browserContext: BrowserContext | undefined;
+    const userDataDir = testInfo.outputPath('extension-user-data-dir');
+    await use({
+      userDataDir,
+      launch: async (mode?: 'disable-extension') => {
+        browserContext = await chromium.launchPersistentContext(userDataDir, {
+          channel: mcpBrowser,
+          // Opening the browser singleton only works in headed.
+          headless: false,
+          // Automation disables singleton browser process behavior, which is necessary for the extension.
+          ignoreDefaultArgs: ['--enable-automation'],
+          args: mode === 'disable-extension' ? [] : [
+            `--disable-extensions-except=${pathToExtension}`,
+            `--load-extension=${pathToExtension}`,
+          ],
+        });
+
+        // for manifest v3:
+        let [serviceWorker] = browserContext.serviceWorkers();
+        if (!serviceWorker)
+          serviceWorker = await browserContext.waitForEvent('serviceworker');
+
+        return browserContext;
+      }
+    });
+    await browserContext?.close();
+
+    // Free up disk space.
+    await fs.rm(userDataDir, { recursive: true, force: true }).catch(() => {});
+  },
+
+  useShortConnectionTimeout: async ({}, use) => {
+    await use((timeoutMs: number) => {
+      process.env.PWMCP_TEST_CONNECTION_TIMEOUT = timeoutMs.toString();
+    });
+    process.env.PWMCP_TEST_CONNECTION_TIMEOUT = undefined;
+  },
+
+  overrideProtocolVersion: async ({}, use) => {
+    await use((version: number) => {
+      process.env.PWMCP_TEST_PROTOCOL_VERSION = version.toString();
+    });
+    process.env.PWMCP_TEST_PROTOCOL_VERSION = undefined;
+  },
+
+  cli: async ({ mcpBrowser }, use, testInfo) => {
+    await use(async (...args: string[]) => {
+      return await runCli(args, { mcpBrowser, testInfo });
+    });
+
+    // Cleanup sessions
+    await runCli(['close-all'], { mcpBrowser, testInfo }).catch(() => {});
+
+    const daemonDir = path.join(testInfo.outputDir, 'daemon');
+    await fs.rm(daemonDir, { recursive: true, force: true }).catch(() => {});
+  },
+});
+
+function cliEnv() {
+  return {
+    PLAYWRIGHT_SERVER_REGISTRY: test.info().outputPath('registry'),
+    PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
+    PLAYWRIGHT_SOCKETS_DIR: path.join(test.info().project.outputDir, 'ds', String(test.info().parallelIndex)),
+  };
+}
+
+async function runCli(
+  args: string[],
+  options: { mcpBrowser?: string, testInfo: any },
+): Promise<CliResult> {
+  const stepTitle = `cli ${args.join(' ')}`;
+
+  return await test.step(stepTitle, async () => {
+    const testInfo = options.testInfo;
+
+    // Path to the terminal CLI
+    const cliPath = path.join(__dirname, '../../../node_modules/playwright-core/lib/tools/cli-client/cli.js');
+
+    return new Promise<CliResult>((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+
+      const childProcess = spawn(process.execPath, [cliPath, ...args], {
+        cwd: testInfo.outputPath(),
+        env: {
+          ...process.env,
+          ...cliEnv(),
+          PLAYWRIGHT_MCP_BROWSER: options.mcpBrowser,
+          PLAYWRIGHT_MCP_HEADLESS: 'false',
+        },
+        detached: true,
+      });
+
+      childProcess.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      childProcess.stderr?.on('data', (data) => {
+        if (process.env.PWMCP_DEBUG)
+          process.stderr.write(data);
+        stderr += data.toString();
+      });
+
+      childProcess.on('close', async (code) => {
+        await testInfo.attach(stepTitle, { body: stdout, contentType: 'text/plain' });
+        resolve({
+          output: stdout.trim(),
+          error: stderr.trim(),
+        });
+      });
+
+      childProcess.on('error', reject);
+    });
+  });
+}
+
+async function startWithExtensionFlag(browserWithExtension: BrowserWithExtension, startClient: StartClient): Promise<Client> {
+  const { client } = await startClient({
+    args: [`--extension`],
+    config: {
+      browser: {
+        userDataDir: browserWithExtension.userDataDir,
+      }
+    },
+  });
+  return client;
+}
+
+const testWithOldExtensionVersion = test.extend({
+  pathToExtension: async ({ pathToExtension }, use, testInfo) => {
+    const manifestPath = path.join(pathToExtension, 'manifest.json');
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+    manifest.key = extensionPublicKey;
+    manifest.version = '0.0.1';
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+    await use(pathToExtension);
+  },
+});
+
+test(`navigate with extension`, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+  console.error('connected');
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+});
+
+test(`browser_tabs new creates a new tab`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/second.html', '<title>Second</title><body>Second page<body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+
+  // Now create a new tab via browser_tabs tool.
+  const newTabResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new', url: server.PREFIX + 'second.html' },
+  });
+
+  expect(newTabResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Second page`),
+  });
+
+  // Verify we have two tabs by listing.
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0: \[Title\]\(.*\/hello-world\)\n- 1: \(current\) \[Second\]\(.*\/second\.html\)/),
+  });
+});
+
+test(`cmd+click opens new tab visible in tab list`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/link-page', '<title>LinkPage</title><body><a href="/target-page">click me</a></body>', 'text/html');
+  server.setContent('/target-page', '<title>TargetPage</title><body>Target content</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + 'link-page' },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`click me`),
+  });
+
+  // Cmd+click (Meta+click) to open link in a new tab.
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'click me', ref: 'e2', modifiers: ['Meta'] },
+  });
+
+  // Wait for the new tab to appear in the list.
+  await expect.poll(async () => {
+    const listResponse = await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'list' },
+    });
+    return (listResponse as any).content?.[0]?.text ?? '';
+  }).toContain('TargetPage');
+
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0:.*\[LinkPage\].*\n- 1:.*\[TargetPage\]/),
+  });
+});
+
+test(`window.open from tracked tab auto-attaches new tab`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/opener-page', `<title>Opener</title><body><button onclick="window.open('${server.PREFIX}opened-page', '_blank', 'noopener')">open</button></body>`, 'text/html');
+  server.setContent('/opened-page', '<title>Opened</title><body>Opened content</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + 'opener-page' },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining('open'),
+  });
+
+  // Click the button that calls window.open.
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'open', ref: 'e2' },
+  });
+
+  // Wait for the new tab to appear in the list.
+  await expect.poll(async () => {
+    const listResponse = await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'list' },
+    });
+    return (listResponse as any).content?.[0]?.text ?? '';
+  }).toContain('Opened');
+
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0:.*\[Opener\].*\n- 1:.*\[Opened\]/),
+  });
+});
+
+test(`snapshot of an existing page`, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+
+  const page = await browserContext.newPage();
+  await page.goto(server.HELLO_WORLD);
+
+  // Another empty page.
+  await browserContext.newPage();
+  expect(browserContext.pages()).toHaveLength(3);
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+  expect(browserContext.pages()).toHaveLength(3);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_snapshot',
+    arguments: { },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  expect(browserContext.pages()).toHaveLength(4);
+
+  await selectorPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+
+  expect(browserContext.pages()).toHaveLength(4);
+});
+
+test(`extension not installed timeout`, async ({ browserWithExtension, startClient, server, useShortConnectionTimeout }) => {
+  useShortConnectionTimeout(100);
+
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    error: expect.stringContaining('Extension connection timeout. Make sure the "Playwright MCP Bridge" extension is installed.'),
+    isError: true,
+  });
+
+  await confirmationPagePromise;
+});
+
+testWithOldExtensionVersion(`works with old extension version`, async ({ browserWithExtension, startClient, server, useShortConnectionTimeout }) => {
+  useShortConnectionTimeout(500);
+
+  // Prelaunch the browser, so that it is properly closed after the test.
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+});
+
+test(`extension needs update`, async ({ browserWithExtension, startClient, server, useShortConnectionTimeout, overrideProtocolVersion }) => {
+  useShortConnectionTimeout(500);
+  overrideProtocolVersion(1000);
+
+  // Prelaunch the browser, so that it is properly closed after the test.
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const confirmationPage = await confirmationPagePromise;
+  await expect(confirmationPage.locator('.status-banner')).toContainText(`Playwright MCP version trying to connect requires newer extension version`);
+
+  expect(await navigateResponse).toHaveResponse({
+    error: expect.stringContaining('Extension connection timeout.'),
+    isError: true,
+  });
+});
+
+test(`custom executablePath`, async ({ startClient, server, useShortConnectionTimeout }) => {
+  useShortConnectionTimeout(1000);
+
+  const executablePath = test.info().outputPath('echo.sh');
+  await fs.writeFile(executablePath, '#!/bin/bash\necho "Custom exec args: $@" > "$(dirname "$0")/output.txt"', { mode: 0o755 });
+
+  const { client } = await startClient({
+    args: [`--extension`],
+    config: {
+      browser: {
+        launchOptions: {
+          executablePath,
+        },
+      }
+    },
+  });
+
+  const navigateResponse = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+  expect(await navigateResponse).toHaveResponse({
+    error: expect.stringContaining('Extension connection timeout.'),
+    isError: true,
+  });
+  expect(await fs.readFile(test.info().outputPath('output.txt'), 'utf8')).toMatch(new RegExp(`Custom exec args.*chrome-extension://${extensionId}/connect\\.html\\?`));
+});
+
+test(`bypass connection dialog with token`, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+
+  const page = await browserContext.newPage();
+  await page.goto(`chrome-extension://${extensionId}/status.html`);
+  const token = await page.locator('.auth-token-code').textContent();
+  const [name, value] = token?.split('=') || [];
+
+  const { client } = await startClient({
+    args: [`--extension`],
+    extensionToken: value,
+    config: {
+      browser: {
+        userDataDir: browserWithExtension.userDataDir,
+      }
+    },
+  });
+
+  const navigateResponse = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+});
+
+test.describe('tab grouping', () => {
+  test('connect page is added to green Playwright group on relay connect', async ({ browserWithExtension, startClient, server }) => {
+    const browserContext = await browserWithExtension.launch();
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+    const connectPagePromise = browserContext.waitForEvent('page', page =>
+      page.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+
+    // Wait for the tab list to appear — this means connectToMCPRelay was processed
+    // by the background and _addTabToGroup has been called.
+    await expect(connectPage.locator('.tab-item').first()).toBeVisible();
+
+    const group = await connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const tab = await chrome.tabs.getCurrent();
+      if (!tab || tab.groupId === -1)
+        return null;
+      const g = await chrome.tabGroups.get(tab.groupId);
+      return { color: g.color, title: g.title };
+    });
+
+    expect(group).toEqual({ color: 'green', title: 'Playwright' });
+
+    await connectPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+    await navigatePromise;
+  });
+
+  test('connected tab is added to same Playwright group', async ({ browserWithExtension, startClient, server }) => {
+    const browserContext = await browserWithExtension.launch();
+
+    const page = await browserContext.newPage();
+    await page.goto(server.HELLO_WORLD);
+
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+    const connectPagePromise = browserContext.waitForEvent('page', page =>
+      page.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+
+    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+    await navigatePromise;
+
+    const { connectGroupId, connectedGroupId } = await connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const connectTab = await chrome.tabs.getCurrent();
+      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+      return {
+        connectGroupId: connectTab?.groupId,
+        connectedGroupId: connectedTab?.groupId,
+      };
+    });
+
+    expect(connectGroupId).not.toBe(-1);
+    expect(connectedGroupId).toBe(connectGroupId);
+  });
+
+  test('connected tab is removed from group on disconnect', async ({ browserWithExtension, startClient, server }) => {
+    const browserContext = await browserWithExtension.launch();
+
+    const page = await browserContext.newPage();
+    await page.goto(server.HELLO_WORLD);
+
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+    const connectPagePromise = browserContext.waitForEvent('page', page =>
+      page.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+
+    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+    await navigatePromise;
+
+    await client.close();
+
+    await expect.poll(async () => {
+      return connectPage.evaluate(async () => {
+        const chrome = (window as any).chrome;
+        const [tab] = await chrome.tabs.query({ title: 'Title' });
+        return tab?.groupId ?? -1;
+      });
+    }).toBe(-1);
+  });
+});
+
+test.describe('CLI with extension', () => {
+  test('attach <url> --extension', async ({ browserWithExtension, cli, server }, testInfo) => {
+    const browserContext = await browserWithExtension.launch();
+
+    // Write config file with userDataDir
+    const configPath = testInfo.outputPath('cli-config.json');
+    await fs.writeFile(configPath, JSON.stringify({
+      browser: {
+        userDataDir: browserWithExtension.userDataDir,
+      }
+    }, null, 2));
+
+    const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+      return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+    });
+
+    // Start the CLI command in the background
+    const cliPromise = cli('attach', '--extension', `--config=cli-config.json`);
+
+    // Wait for the confirmation page to appear
+    const confirmationPage = await confirmationPagePromise;
+
+    // Click the Connect button
+    await confirmationPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+    {
+      // Wait for the CLI command to complete
+      const { output } = await cliPromise;
+      // Verify the output
+      expect(output).toContain(`### Page`);
+      expect(output).toContain(`- Page URL: chrome-extension://${extensionId}/connect.html?`);
+      expect(output).toContain(`- Page Title: Playwright MCP extension`);
+    }
+
+    {
+      const { output } = await cli('goto', server.HELLO_WORLD);
+      // Verify the output
+      expect(output).toContain(`### Page`);
+      expect(output).toContain(`- Page URL: ${server.HELLO_WORLD}`);
+      expect(output).toContain(`- Page Title: Title`);
+    }
+  });
+});

--- a/packages/extension/protocol-v1-compat/tests/extension.spec.ts
+++ b/packages/extension/protocol-v1-compat/tests/extension.spec.ts
@@ -15,6 +15,8 @@
  */
 
 import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
 import path from 'path';
 import { chromium } from 'playwright';
 import { spawn } from 'child_process';
@@ -57,7 +59,6 @@ const test = base.extend<TestFixtures>({
     // in the store.
     manifest.key = extensionPublicKey;
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-    console.log(`Extension path: ${extensionDir}`);
     await use(extensionDir);
   },
 
@@ -125,10 +126,11 @@ const test = base.extend<TestFixtures>({
 });
 
 function cliEnv() {
+  const shortTmp = fsSync.mkdtempSync(path.join(os.tmpdir(), 'pw-mcp-v1-compat-'));
   return {
     PLAYWRIGHT_SERVER_REGISTRY: test.info().outputPath('registry'),
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
-    PLAYWRIGHT_SOCKETS_DIR: path.join(test.info().project.outputDir, 'ds', String(test.info().parallelIndex)),
+    PLAYWRIGHT_SOCKETS_DIR: path.join(shortTmp, 'ds', String(test.info().parallelIndex)),
   };
 }
 
@@ -142,8 +144,7 @@ async function runCli(
     const testInfo = options.testInfo;
 
     // Path to the terminal CLI
-    const cliPath = path.join(__dirname, '../../../node_modules/playwright-core/lib/tools/cli-client/cli.js');
-
+    const cliPath = path.join(__dirname, '../node_modules/@playwright/cli/playwright-cli.js');
     return new Promise<CliResult>((resolve, reject) => {
       let stdout = '';
       let stderr = '';

--- a/packages/extension/protocol-v1-compat/tests/fixtures.ts
+++ b/packages/extension/protocol-v1-compat/tests/fixtures.ts
@@ -1,0 +1,302 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { chromium } from 'playwright';
+
+import { test as baseTest, expect as baseExpect } from '@playwright/test';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { TestServer } from '../../../playwright-mcp/tests/testserver/index';
+
+import type { BrowserContext } from 'playwright';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { Stream } from 'stream';
+
+export type TestOptions = {
+  mcpArgs: string[] | undefined;
+  mcpBrowser: string | undefined;
+  mcpMode: 'docker' | undefined;
+};
+
+type CDPServer = {
+  endpoint: string;
+  start: () => Promise<BrowserContext>;
+};
+
+type Config = any;
+
+export type StartClient = (options?: {
+  clientName?: string,
+  args?: string[],
+  config?: Config,
+  roots?: { name: string, uri: string }[],
+  rootsResponseDelay?: number,
+  extensionToken?: string,
+}) => Promise<{ client: Client, stderr: () => string }>;
+
+
+type TestFixtures = {
+  client: Client;
+  startClient: StartClient;
+  wsEndpoint: string;
+  cdpServer: CDPServer;
+  server: TestServer;
+  httpsServer: TestServer;
+  mcpHeadless: boolean;
+};
+
+type WorkerFixtures = {
+  _workerServers: { server: TestServer, httpsServer: TestServer };
+};
+
+export const test = baseTest.extend<TestFixtures & TestOptions, WorkerFixtures>({
+
+  mcpArgs: [undefined, { option: true }],
+
+  client: async ({ startClient }, use) => {
+    const { client } = await startClient();
+    await use(client);
+  },
+
+  startClient: async ({ mcpHeadless, mcpBrowser, mcpMode, mcpArgs }, use, testInfo) => {
+    const clients: Client[] = [];
+
+    await use(async options => {
+      const cwd = testInfo.outputPath();
+      const args: string[] = mcpArgs ?? [];
+      if (process.env.CI && process.platform === 'linux')
+        args.push('--no-sandbox');
+      if (mcpHeadless)
+        args.push('--headless');
+      if (mcpBrowser)
+        args.push(`--browser=${mcpBrowser}`);
+      if (options?.args)
+        args.push(...options.args);
+      if (options?.config) {
+        const configFile = testInfo.outputPath('config.json');
+        await fs.promises.writeFile(configFile, JSON.stringify(options.config, null, 2));
+        args.push(`--config=${path.relative(cwd, configFile)}`);
+      }
+
+      const client = new Client({ name: options?.clientName ?? 'test', version: '1.0.0' }, options?.roots ? { capabilities: { roots: {} } } : undefined);
+      if (options?.roots) {
+        client.setRequestHandler(ListRootsRequestSchema, async request => {
+          if (options.rootsResponseDelay)
+            await new Promise(resolve => setTimeout(resolve, options.rootsResponseDelay));
+          return {
+            roots: options.roots,
+          };
+        });
+      }
+      const { transport, stderr } = await createTransport(args, cwd, mcpMode, testInfo.outputPath('ms-playwright'), options?.extensionToken);
+      let stderrBuffer = '';
+      stderr?.on('data', data => {
+        if (process.env.PWMCP_DEBUG)
+          process.stderr.write(data);
+        stderrBuffer += data.toString();
+      });
+      clients.push(client);
+      await client.connect(transport);
+      await client.ping();
+      return { client, stderr: () => stderrBuffer };
+    });
+
+    await Promise.all(clients.map(client => client.close()));
+  },
+
+  wsEndpoint: async ({ }, use) => {
+    const browserServer = await chromium.launchServer();
+    await use(browserServer.wsEndpoint());
+    await browserServer.close();
+  },
+
+  cdpServer: async ({ mcpBrowser }, use, testInfo) => {
+    test.skip(!['chrome', 'msedge', 'chromium'].includes(mcpBrowser!), 'CDP is not supported for non-Chromium browsers');
+
+    let browserContext: BrowserContext | undefined;
+    const port = 3200 + test.info().parallelIndex;
+    await use({
+      endpoint: `http://localhost:${port}`,
+      start: async () => {
+        if (browserContext)
+          throw new Error('CDP server already exists');
+        browserContext = await chromium.launchPersistentContext(testInfo.outputPath('cdp-user-data-dir'), {
+          channel: mcpBrowser,
+          headless: true,
+          args: [
+            `--remote-debugging-port=${port}`,
+          ],
+        });
+        return browserContext;
+      }
+    });
+    await browserContext?.close();
+  },
+
+  mcpHeadless: async ({ headless }, use) => {
+    await use(headless);
+  },
+
+  mcpBrowser: ['chrome', { option: true }],
+
+  mcpMode: [undefined, { option: true }],
+
+  _workerServers: [async ({ }, use, workerInfo) => {
+    const port = 8907 + workerInfo.workerIndex * 4;
+    const server = await TestServer.create(port);
+
+    const httpsPort = port + 1;
+    const httpsServer = await TestServer.createHTTPS(httpsPort);
+
+    await use({ server, httpsServer });
+
+    await Promise.all([
+      server.stop(),
+      httpsServer.stop(),
+    ]);
+  }, { scope: 'worker' }],
+
+  server: async ({ _workerServers }, use) => {
+    _workerServers.server.reset();
+    await use(_workerServers.server);
+  },
+
+  httpsServer: async ({ _workerServers }, use) => {
+    _workerServers.httpsServer.reset();
+    await use(_workerServers.httpsServer);
+  },
+});
+
+async function createTransport(args: string[], cwd: string, mcpMode: TestOptions['mcpMode'], profilesDir: string, extensionToken?: string): Promise<{
+  transport: Transport,
+  stderr: Stream | null,
+}> {
+  if (mcpMode === 'docker')
+    throw new Error('Docker mode is not supported in protocol-v1-compat tests');
+
+  const mcpPath = path.join(path.dirname(require.resolve('@playwright/mcp')), 'cli.js');
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [mcpPath, ...args],
+    cwd,
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      DEBUG: 'pw:mcp:test',
+      DEBUG_COLORS: '0',
+      DEBUG_HIDE_DATE: '1',
+      PWMCP_PROFILES_DIR_FOR_TEST: profilesDir,
+      ...(extensionToken ? { PLAYWRIGHT_MCP_EXTENSION_TOKEN: extensionToken } : {}),
+    },
+  });
+  return {
+    transport,
+    stderr: transport.stderr!,
+  };
+}
+
+type Response = Awaited<ReturnType<Client['callTool']>>;
+
+export const expect = baseExpect.extend({
+  toHaveResponse(response: Response, object: any) {
+    const parsed = parseResponse(response, test.info().outputPath());
+    const isNot = this.isNot;
+    try {
+      if (isNot)
+        expect(parsed).not.toEqual(expect.objectContaining(object));
+      else
+        expect(parsed).toEqual(expect.objectContaining(object));
+    } catch (e: any) {
+      return {
+        pass: isNot,
+        message: () => e.message,
+      };
+    }
+    return {
+      pass: !isNot,
+      message: () => ``,
+    };
+  },
+});
+
+export function formatOutput(output: string): string[] {
+  return output.split('\n').map(line => line.replace(/^pw:mcp:test /, '').replace(/user data dir.*/, 'user data dir').trim()).filter(Boolean);
+}
+
+function parseResponse(response: any, cwd: string) {
+  const text = response.content[0].text;
+  const sections = parseSections(text);
+
+  const error = sections.get('Error');
+  const result = sections.get('Result');
+  const code = sections.get('Ran Playwright code');
+  const tabs = sections.get('Open tabs');
+  const pageState = sections.get('Page state');
+  const snapshotSection = sections.get('Snapshot');
+  const consoleMessages = sections.get('New console messages');
+  const modalState = sections.get('Modal state');
+  const downloads = sections.get('Downloads');
+  const codeNoFrame = code?.replace(/^```js\n/, '').replace(/\n```$/, '');
+  const isError = response.isError;
+  const attachments = response.content.slice(1);
+
+  let snapshot: string | undefined;
+  if (snapshotSection) {
+    const match = snapshotSection.match(/\[Snapshot\]\(([^)]+)\)/);
+    if (match) {
+      try {
+        snapshot = fs.readFileSync(path.resolve(cwd, match[1]), 'utf-8');
+      } catch {
+      }
+    } else {
+      snapshot = snapshotSection.replace(/^```yaml\n?/, '').replace(/\n?```$/, '');
+    }
+  }
+
+  return {
+    error,
+    result,
+    code: codeNoFrame,
+    tabs,
+    pageState,
+    snapshot,
+    consoleMessages,
+    modalState,
+    downloads,
+    isError,
+    attachments,
+  };
+}
+
+function parseSections(text: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const sectionHeaders = text.split(/^### /m).slice(1); // Remove empty first element
+
+  for (const section of sectionHeaders) {
+    const firstNewlineIndex = section.indexOf('\n');
+    if (firstNewlineIndex === -1)
+      continue;
+
+    const sectionName = section.substring(0, firstNewlineIndex);
+    const sectionContent = section.substring(firstNewlineIndex + 1).trim();
+    sections.set(sectionName, sectionContent);
+  }
+
+  return sections;
+}

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -19,6 +19,7 @@ import { RelayConnection, debugLog } from './relayConnection';
 type PageMessage = {
   type: 'connectToMCPRelay';
   mcpRelayUrl: string;
+  protocolVersion: number;
 } | {
   type: 'getTabs';
 } | {
@@ -34,7 +35,7 @@ type PageMessage = {
 
 class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
-  private _connectedTabId: number | null = null;
+  private _connectedTabIds: Set<number> = new Set();
   private _groupId: number | null = null;
   private _pendingTabSelection = new Map<number, { connection: RelayConnection, timerId?: number }>();
 
@@ -50,7 +51,7 @@ class TabShareExtension {
   private _onMessage(message: PageMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: any) => void) {
     switch (message.type) {
       case 'connectToMCPRelay':
-        this._connectToRelay(sender.tab!.id!, message.mcpRelayUrl).then(
+        this._connectToRelay(sender.tab!.id!, message.mcpRelayUrl, message.protocolVersion).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true;
@@ -68,7 +69,7 @@ class TabShareExtension {
         return true; // Return true to indicate that the response will be sent asynchronously
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabId: this._connectedTabId
+          connectedTabIds: [...this._connectedTabIds]
         });
         return false;
       case 'disconnect':
@@ -80,9 +81,9 @@ class TabShareExtension {
     return false;
   }
 
-  private async _connectToRelay(selectorTabId: number, mcpRelayUrl: string): Promise<void> {
+  private async _connectToRelay(selectorTabId: number, mcpRelayUrl: string, protocolVersion: number): Promise<void> {
     try {
-      debugLog(`Connecting to relay at ${mcpRelayUrl}`);
+      debugLog(`Connecting to relay at ${mcpRelayUrl} (protocol v${protocolVersion})`);
       const socket = new WebSocket(mcpRelayUrl);
       await new Promise<void>((resolve, reject) => {
         socket.onopen = () => resolve();
@@ -90,7 +91,7 @@ class TabShareExtension {
         setTimeout(() => reject(new Error('Connection timeout')), 5000);
       });
 
-      const connection = new RelayConnection(socket);
+      const connection = new RelayConnection(socket, protocolVersion);
       connection.onclose = () => {
         debugLog('Connection closed');
         this._pendingTabSelection.delete(selectorTabId);
@@ -114,42 +115,44 @@ class TabShareExtension {
       } catch (error: any) {
         debugLog(`Error closing active connection:`, error);
       }
-      await this._setConnectedTabId(null);
+      await Promise.all([...this._connectedTabIds].map(id => this._updateBadge(id, { text: '' })));
+      this._connectedTabIds.clear();
 
       this._activeConnection = this._pendingTabSelection.get(selectorTabId)?.connection;
       if (!this._activeConnection)
         throw new Error('No active MCP relay connection');
       this._pendingTabSelection.delete(selectorTabId);
 
-      this._activeConnection.setTabId(tabId);
+      this._activeConnection.setSelectedTab(tabId);
       this._activeConnection.onclose = () => {
         debugLog('MCP connection closed');
         this._activeConnection = undefined;
-        void this._setConnectedTabId(null);
-        chrome.tabs.ungroup([tabId]).catch(() => {});
+        const allTabIds = [...this._connectedTabIds];
+        this._connectedTabIds.clear();
+        allTabIds.map(id => this._updateBadge(id, { text: '' }));
+        chrome.tabs.ungroup(allTabIds).catch(() => {});
+      };
+      this._activeConnection.ontabattached = (newTabId: number) => {
+        this._connectedTabIds.add(newTabId);
+        void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
+        void this._addTabToGroup(newTabId);
+      };
+      this._activeConnection.ontabdetached = (removedTabId: number) => {
+        this._connectedTabIds.delete(removedTabId);
+        void this._updateBadge(removedTabId, { text: '' });
+        chrome.tabs.ungroup(removedTabId).catch(() => {});
       };
 
       await Promise.all([
-        this._setConnectedTabId(tabId),
-        this._addTabToGroup(tabId),
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
       debugLog(`Connected to MCP bridge`);
     } catch (error: any) {
-      await this._setConnectedTabId(null);
+      this._connectedTabIds.clear();
       debugLog(`Failed to connect tab ${tabId}:`, error.message);
       throw error;
     }
-  }
-
-  private async _setConnectedTabId(tabId: number | null): Promise<void> {
-    const oldTabId = this._connectedTabId;
-    this._connectedTabId = tabId;
-    if (oldTabId && oldTabId !== tabId)
-      await this._updateBadge(oldTabId, { text: '' });
-    if (tabId)
-      await this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
   }
 
   private async _updateBadge(tabId: number, { text, color, title }: { text: string; color?: string, title?: string }): Promise<void> {
@@ -170,11 +173,9 @@ class TabShareExtension {
       pendingConnection.close('Browser tab closed');
       return;
     }
-    if (this._connectedTabId !== tabId)
-      return;
-    this._activeConnection?.close('Browser tab closed');
-    this._activeConnection = undefined;
-    this._connectedTabId = null;
+    // Tab removal is handled by RelayConnection (ontabdetached / onclose).
+    // No action needed here — the relay detects it via chrome.tabs.onRemoved
+    // and chrome.debugger.onDetach listeners.
   }
 
   private _onTabActivated(activeInfo: chrome.tabs.TabActiveInfo) {
@@ -199,8 +200,8 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    if (this._connectedTabId === tabId)
-      void this._setConnectedTabId(tabId);
+    if (this._connectedTabIds.has(tabId))
+      void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
@@ -238,7 +239,8 @@ class TabShareExtension {
   private async _disconnect(): Promise<void> {
     this._activeConnection?.close('User disconnected');
     this._activeConnection = undefined;
-    await this._setConnectedTabId(null);
+    await Promise.all([...this._connectedTabIds].map(id => this._updateBadge(id, { text: '' })));
+    this._connectedTabIds.clear();
   }
 }
 

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -36,34 +36,57 @@ type ProtocolResponse = {
   error?: string;
 };
 
+// Allow-listed chrome.* commands the relay may invoke. The handler resolves
+// the method reflectively and spreads positional params.
+const ALLOWED_CHROME_COMMANDS = new Set([
+  'chrome.debugger.attach',
+  'chrome.debugger.detach',
+  'chrome.debugger.sendCommand',
+  'chrome.tabs.create',
+]);
+
+// chrome.* events the extension forwards to the relay (positional params).
+type ChromeEvent = {
+  api: 'chrome.debugger' | 'chrome.tabs';
+  event: 'onEvent' | 'onDetach' | 'onCreated' | 'onRemoved';
+  fullMethod: string;
+};
+
+const CHROME_EVENTS: ChromeEvent[] = [
+  { api: 'chrome.debugger', event: 'onEvent',   fullMethod: 'chrome.debugger.onEvent' },
+  { api: 'chrome.debugger', event: 'onDetach',  fullMethod: 'chrome.debugger.onDetach' },
+  { api: 'chrome.tabs',     event: 'onCreated', fullMethod: 'chrome.tabs.onCreated' },
+  { api: 'chrome.tabs',     event: 'onRemoved', fullMethod: 'chrome.tabs.onRemoved' },
+];
+
 export class RelayConnection {
-  private _debuggee: chrome.debugger.Debuggee;
   private _ws: WebSocket;
-  private _eventListener: (source: chrome.debugger.DebuggerSession, method: string, params: any) => void;
-  private _detachListener: (source: chrome.debugger.Debuggee, reason: string) => void;
-  private _tabPromise: Promise<void>;
-  private _tabPromiseResolve!: () => void;
+  private _protocolVersion: number;
+  // Tabs whose debugger we have explicitly attached for this connection.
+  private _attachedTabs = new Set<number>();
+  // Once we've attached at least one tab, detaching the last one closes the connection.
+  private _hasEverAttached = false;
+  private _eventListeners: Array<{ remove: () => void }> = [];
+  private _selectedTabPromise: Promise<number>;
+  private _selectedTabResolve!: (tabId: number) => void;
   private _closed = false;
 
   onclose?: () => void;
+  ontabattached?: (tabId: number) => void;
+  ontabdetached?: (tabId: number) => void;
 
-  constructor(ws: WebSocket) {
-    this._debuggee = { };
-    this._tabPromise = new Promise(resolve => this._tabPromiseResolve = resolve);
+  constructor(ws: WebSocket, protocolVersion: number) {
     this._ws = ws;
+    this._protocolVersion = protocolVersion;
+    this._selectedTabPromise = new Promise(resolve => this._selectedTabResolve = resolve);
+    this._installEventForwarders();
     this._ws.onmessage = this._onMessage.bind(this);
     this._ws.onclose = () => this._onClose();
-    // Store listeners for cleanup
-    this._eventListener = this._onDebuggerEvent.bind(this);
-    this._detachListener = this._onDebuggerDetach.bind(this);
-    chrome.debugger.onEvent.addListener(this._eventListener);
-    chrome.debugger.onDetach.addListener(this._detachListener);
   }
 
-  // Either setTabId or close is called after creating the connection.
-  setTabId(tabId: number): void {
-    this._debuggee = { tabId };
-    this._tabPromiseResolve();
+  // Resolves the pending extension.selectTab call from cdpRelay.
+  setSelectedTab(tabId: number): void {
+    this._selectedTabResolve(tabId);
   }
 
   close(message: string): void {
@@ -73,36 +96,84 @@ export class RelayConnection {
     this._onClose();
   }
 
+  private _installEventForwarders(): void {
+    for (const { fullMethod } of CHROME_EVENTS) {
+      const target = this._resolveChromeMember(fullMethod);
+      const listener = (...args: any[]) => this._onChromeEvent(fullMethod, args);
+      target.obj[target.name].addListener(listener);
+      this._eventListeners.push({
+        remove: () => target.obj[target.name].removeListener(listener),
+      });
+    }
+  }
+
   private _onClose() {
     if (this._closed)
       return;
     this._closed = true;
-    chrome.debugger.onEvent.removeListener(this._eventListener);
-    chrome.debugger.onDetach.removeListener(this._detachListener);
-    chrome.debugger.detach(this._debuggee).catch(() => {});
+    for (const l of this._eventListeners)
+      l.remove();
+    this._eventListeners = [];
+    for (const tabId of this._attachedTabs)
+      chrome.debugger.detach({ tabId }).catch(() => {});
+    this._attachedTabs.clear();
     this.onclose?.();
   }
 
-  private _onDebuggerEvent(source: chrome.debugger.DebuggerSession, method: string, params: any): void {
-    if (source.tabId !== this._debuggee.tabId)
-      return;
-    debugLog('Forwarding CDP event:', method, params);
-    const sessionId = source.sessionId;
-    this._sendMessage({
-      method: 'forwardCDPEvent',
-      params: {
-        sessionId,
-        method,
-        params,
-      },
-    });
+  private _checkLastTabDetached(): void {
+    if (this._hasEverAttached && this._attachedTabs.size === 0)
+      this.close('All controlled tabs detached');
   }
 
-  private _onDebuggerDetach(source: chrome.debugger.Debuggee, reason: string): void {
-    if (source.tabId !== this._debuggee.tabId)
+  // Single dispatcher for every forwarded chrome.* event.
+  private _onChromeEvent(fullMethod: string, args: any[]): void {
+    // Filter events to those concerning tabs we've explicitly attached.
+    const tabId = this._tabIdForEventArgs(fullMethod, args);
+    if (tabId === undefined || !this._attachedTabs.has(tabId))
       return;
-    this.close(`Debugger detached: ${reason}`);
-    this._debuggee = { };
+
+    // v1 only forwards CDP events from the single attached tab.
+    if (this._protocolVersion === 1) {
+      if (fullMethod === 'chrome.debugger.onEvent') {
+        const [source, method, params] = args as [chrome.debugger.DebuggerSession, string, any];
+        this._sendMessage({
+          method: 'forwardCDPEvent',
+          params: {
+            sessionId: source.sessionId,
+            method,
+            params,
+          },
+        });
+      }
+      // Other events have no v1 equivalent — drop them. Detach bookkeeping happens below.
+    } else {
+      this._sendMessage({ method: fullMethod, params: args });
+    }
+
+    // Detach bookkeeping (single source of truth: chrome.debugger.onDetach).
+    if (fullMethod === 'chrome.debugger.onDetach') {
+      this._attachedTabs.delete(tabId);
+      this.ontabdetached?.(tabId);
+      this._checkLastTabDetached();
+    }
+  }
+
+  // Returns the tabId an event refers to, for filtering by _attachedTabs.
+  private _tabIdForEventArgs(fullMethod: string, args: any[]): number | undefined {
+    switch (fullMethod) {
+      case 'chrome.debugger.onEvent':
+      case 'chrome.debugger.onDetach':
+        return (args[0] as chrome.debugger.Debuggee | undefined)?.tabId;
+      case 'chrome.tabs.onCreated': {
+        const tab = args[0] as chrome.tabs.Tab;
+        // Forward only popups opened by an attached tab; report the opener so cdpRelay
+        // can filter / decide. We use the openerTabId for the attached-tab check.
+        return tab.openerTabId;
+      }
+      case 'chrome.tabs.onRemoved':
+        return args[0] as number;
+    }
+    return undefined;
   }
 
   private _onMessage(event: MessageEvent): void {
@@ -135,31 +206,76 @@ export class RelayConnection {
   }
 
   private async _handleCommand(message: ProtocolCommand): Promise<any> {
-    if (message.method === 'attachToTab') {
-      await this._tabPromise;
-      debugLog('Attaching debugger to tab:', this._debuggee);
-      await chrome.debugger.attach(this._debuggee, '1.3');
-      const result: any = await chrome.debugger.sendCommand(this._debuggee, 'Target.getTargetInfo');
-      return {
-        targetInfo: result?.targetInfo,
-      };
+    // Playwright-specific tab picker.
+    if (message.method === 'extension.selectTab') {
+      const tabId = await this._selectedTabPromise;
+      return { tabId };
     }
-    if (!this._debuggee.tabId)
-      throw new Error('No tab is connected. Please go to the Playwright MCP extension and select the tab you want to connect to.');
+
+    // Reflective chrome.* dispatch: spread positional params into the API.
+    if (ALLOWED_CHROME_COMMANDS.has(message.method)) {
+      const args = (message.params ?? []) as any[];
+      const result = await this._invokeChromeMethod(message.method, args);
+      this._postChromeCommand(message.method, args);
+      return result ?? {};
+    }
+
+    // ─── Protocol v1 (legacy single-tab) ─────────────────────────────────────
+    if (message.method === 'attachToTab') {
+      const tabId = await this._selectedTabPromise;
+      const debuggee: chrome.debugger.Debuggee = { tabId };
+      await chrome.debugger.attach(debuggee, '1.3');
+      this._attachedTabs.add(tabId);
+      this._hasEverAttached = true;
+      this.ontabattached?.(tabId);
+      const result: any = await chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo');
+      return { targetInfo: result?.targetInfo };
+    }
     if (message.method === 'forwardCDPCommand') {
       const { sessionId, method, params } = message.params;
-      debugLog('CDP command:', method, params);
-      const debuggerSession: chrome.debugger.DebuggerSession = {
-        ...this._debuggee,
-        sessionId,
-      };
-      // Forward CDP command to chrome.debugger
-      return await chrome.debugger.sendCommand(
-          debuggerSession,
-          method,
-          params
-      );
+      const tabId = [...this._attachedTabs][0];
+      if (tabId === undefined)
+        throw new Error('No tab is connected');
+      const debuggerSession: chrome.debugger.DebuggerSession = { tabId, sessionId };
+      return await chrome.debugger.sendCommand(debuggerSession, method, params);
     }
+
+    throw new Error(`Unknown method: ${message.method}`);
+  }
+
+  // Reflectively resolves chrome.<api>.<member> and invokes it with positional args.
+  private async _invokeChromeMethod(fullMethod: string, args: any[]): Promise<any> {
+    const { obj, name } = this._resolveChromeMember(fullMethod);
+    const fn = obj[name] as (...a: any[]) => any;
+    if (typeof fn !== 'function')
+      throw new Error(`Not a function: ${fullMethod}`);
+    return await fn.apply(obj, args);
+  }
+
+  // Bookkeeping that must run after a successful chrome.* command.
+  private _postChromeCommand(fullMethod: string, args: any[]): void {
+    if (fullMethod === 'chrome.debugger.attach') {
+      const target = args[0] as chrome.debugger.Debuggee;
+      if (target.tabId !== undefined) {
+        this._attachedTabs.add(target.tabId);
+        this._hasEverAttached = true;
+        this.ontabattached?.(target.tabId);
+      }
+    }
+    // Detach is handled via the chrome.debugger.onDetach event listener.
+  }
+
+  private _resolveChromeMember(fullMethod: string): { obj: any; name: string } {
+    const parts = fullMethod.split('.');
+    if (parts[0] !== 'chrome' || parts.length < 3)
+      throw new Error(`Invalid chrome method: ${fullMethod}`);
+    let obj: any = chrome;
+    for (let i = 1; i < parts.length - 1; i++) {
+      obj = obj?.[parts[i]];
+      if (obj === undefined)
+        throw new Error(`Unknown chrome path: ${parts.slice(0, i + 1).join('.')}, calling ${fullMethod}`);
+    }
+    return { obj, name: parts[parts.length - 1] };
   }
 
   private _sendError(code: number, message: string): void {

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -36,7 +36,6 @@ const ConnectApp: React.FC = () => {
   const [showTabList, setShowTabList] = useState(true);
   const [clientInfo, setClientInfo] = useState('unknown');
   const [mcpRelayUrl, setMcpRelayUrl] = useState('');
-  const [protocolVersion, setProtocolVersion] = useState<number>(SUPPORTED_PROTOCOL_VERSION);
   const [newTab, setNewTab] = useState<boolean>(false);
 
   useEffect(() => {
@@ -76,9 +75,8 @@ const ConnectApp: React.FC = () => {
       }
 
       const parsedVersion = parseInt(params.get('protocolVersion') ?? '', 10);
-      const requiredVersion = isNaN(parsedVersion) ? 1 : parsedVersion;
-      setProtocolVersion(requiredVersion);
-      if (requiredVersion > SUPPORTED_PROTOCOL_VERSION) {
+      const requestedVersion = isNaN(parsedVersion) ? 1 : parsedVersion;
+      if (requestedVersion > SUPPORTED_PROTOCOL_VERSION) {
         const extensionVersion = chrome.runtime.getManifest().version;
         setShowButtons(false);
         setShowTabList(false);
@@ -94,7 +92,7 @@ const ConnectApp: React.FC = () => {
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
       if (token === expectedToken) {
-        await connectToMCPRelay(relayUrl);
+        await connectToMCPRelay(relayUrl, requestedVersion);
         await handleConnectToTab();
         return;
       }
@@ -103,7 +101,7 @@ const ConnectApp: React.FC = () => {
         return;
       }
 
-      await connectToMCPRelay(relayUrl);
+      await connectToMCPRelay(relayUrl, requestedVersion);
 
       // If this is a browser_navigate command, hide the tab list and show simple allow/reject
       if (params.get('newTab') === 'true') {
@@ -122,11 +120,11 @@ const ConnectApp: React.FC = () => {
     setStatus({ type: 'error', message });
   }, []);
 
-  const connectToMCPRelay = useCallback(async (mcpRelayUrl: string) => {
+  const connectToMCPRelay = useCallback(async (mcpRelayUrl: string, protocolVersion: number) => {
     const response = await chrome.runtime.sendMessage({ type: 'connectToMCPRelay', mcpRelayUrl, protocolVersion });
     if (!response.success)
       handleReject(response.error);
-  }, [handleReject, protocolVersion]);
+  }, [handleReject]);
 
   const loadTabs = useCallback(async () => {
     const response = await chrome.runtime.sendMessage({ type: 'getTabs' });

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -27,7 +27,7 @@ type Status =
   | { type: 'error'; message: string }
   | { type: 'error'; versionMismatch: { extensionVersion: string; } };
 
-const SUPPORTED_PROTOCOL_VERSION = 1;
+const SUPPORTED_PROTOCOL_VERSION = 2;
 
 const ConnectApp: React.FC = () => {
   const [tabs, setTabs] = useState<TabInfo[]>([]);
@@ -36,6 +36,7 @@ const ConnectApp: React.FC = () => {
   const [showTabList, setShowTabList] = useState(true);
   const [clientInfo, setClientInfo] = useState('unknown');
   const [mcpRelayUrl, setMcpRelayUrl] = useState('');
+  const [protocolVersion, setProtocolVersion] = useState<number>(SUPPORTED_PROTOCOL_VERSION);
   const [newTab, setNewTab] = useState<boolean>(false);
 
   useEffect(() => {
@@ -76,6 +77,7 @@ const ConnectApp: React.FC = () => {
 
       const parsedVersion = parseInt(params.get('protocolVersion') ?? '', 10);
       const requiredVersion = isNaN(parsedVersion) ? 1 : parsedVersion;
+      setProtocolVersion(requiredVersion);
       if (requiredVersion > SUPPORTED_PROTOCOL_VERSION) {
         const extensionVersion = chrome.runtime.getManifest().version;
         setShowButtons(false);
@@ -121,10 +123,10 @@ const ConnectApp: React.FC = () => {
   }, []);
 
   const connectToMCPRelay = useCallback(async (mcpRelayUrl: string) => {
-    const response = await chrome.runtime.sendMessage({ type: 'connectToMCPRelay', mcpRelayUrl  });
+    const response = await chrome.runtime.sendMessage({ type: 'connectToMCPRelay', mcpRelayUrl, protocolVersion });
     if (!response.success)
       handleReject(response.error);
-  }, [handleReject]);
+  }, [handleReject, protocolVersion]);
 
   const loadTabs = useCallback(async () => {
     const response = await chrome.runtime.sendMessage({ type: 'getTabs' });

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -21,50 +21,35 @@ import { Button, TabItem  } from './tabItem';
 import type { TabInfo } from './tabItem';
 import { AuthTokenSection } from './authToken';
 
-interface ConnectionStatus {
-  isConnected: boolean;
-  connectedTabId: number | null;
-  connectedTab?: TabInfo;
-}
-
 const StatusApp: React.FC = () => {
-  const [status, setStatus] = useState<ConnectionStatus>({
-    isConnected: false,
-    connectedTabId: null
-  });
+  const [connectedTabs, setConnectedTabs] = useState<TabInfo[]>([]);
 
   useEffect(() => {
     void loadStatus();
   }, []);
 
   const loadStatus = async () => {
-    // Get current connection status from background script
-    const { connectedTabId } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
-    if (connectedTabId) {
-      const tab = await chrome.tabs.get(connectedTabId);
-      setStatus({
-        isConnected: true,
-        connectedTabId,
-        connectedTab: {
+    const { connectedTabIds } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+    const tabs: TabInfo[] = [];
+    for (const tabId of (connectedTabIds as number[] ?? [])) {
+      try {
+        const tab = await chrome.tabs.get(tabId);
+        tabs.push({
           id: tab.id!,
           windowId: tab.windowId!,
           title: tab.title!,
           url: tab.url!,
           favIconUrl: tab.favIconUrl
-        }
-      });
-    } else {
-      setStatus({
-        isConnected: false,
-        connectedTabId: null
-      });
+        });
+      } catch {
+        // Tab may have been closed.
+      }
     }
+    setConnectedTabs(tabs);
   };
 
-  const openConnectedTab = async () => {
-    if (!status.connectedTabId)
-      return;
-    await chrome.tabs.update(status.connectedTabId, { active: true });
+  const openTab = async (tabId: number) => {
+    await chrome.tabs.update(tabId, { active: true });
     window.close();
   };
 
@@ -76,21 +61,24 @@ const StatusApp: React.FC = () => {
   return (
     <div className='app-container'>
       <div className='content-wrapper'>
-        {status.isConnected && status.connectedTab ? (
+        {connectedTabs.length > 0 ? (
           <div>
             <div className='tab-section-title'>
-              Page with connected MCP client:
+              {connectedTabs.length === 1 ? 'Page connected to MCP client:' : 'Pages connected to MCP client:'}
             </div>
             <div>
-              <TabItem
-                tab={status.connectedTab}
-                button={
-                  <Button variant='primary' onClick={disconnect}>
-                    Disconnect
-                  </Button>
-                }
-                onClick={openConnectedTab}
-              />
+              {connectedTabs.map((tab, index) => (
+                <TabItem
+                  key={tab.id}
+                  tab={tab}
+                  button={index === 0 ? (
+                    <Button variant='primary' onClick={disconnect}>
+                      Disconnect
+                    </Button>
+                  ) : undefined}
+                  onClick={() => openTab(tab.id)}
+                />
+              ))}
             </div>
           </div>
         ) : (

--- a/packages/extension/tests/extension.spec.ts
+++ b/packages/extension/tests/extension.spec.ts
@@ -226,6 +226,227 @@ test(`navigate with extension`, async ({ browserWithExtension, startClient, serv
   });
 });
 
+test(`browser_tabs new creates a new tab`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/second.html', '<title>Second</title><body>Second page<body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+  });
+
+  // Now create a new tab via browser_tabs tool.
+  const newTabResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new', url: server.PREFIX + 'second.html' },
+  });
+
+  expect(newTabResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Second page`),
+  });
+
+  // Verify we have two tabs by listing.
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0: \[Title\]\(.*\/hello-world\)\n- 1: \(current\) \[Second\]\(.*\/second\.html\)/),
+  });
+});
+
+test(`cmd+click opens new tab visible in tab list`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/link-page', '<title>LinkPage</title><body><a href="/target-page">click me</a></body>', 'text/html');
+  server.setContent('/target-page', '<title>TargetPage</title><body>Target content</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + 'link-page' },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining(`click me`),
+  });
+
+  // Cmd+click (Meta+click) to open link in a new tab.
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'click me', ref: 'e2', modifiers: ['Meta'] },
+  });
+
+  // Wait for the new tab to appear in the list.
+  await expect.poll(async () => {
+    const listResponse = await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'list' },
+    });
+    return (listResponse as any).content?.[0]?.text ?? '';
+  }).toContain('TargetPage');
+
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0:.*\[LinkPage\].*\n- 1:.*\[TargetPage\]/),
+  });
+});
+
+test(`window.open from tracked tab auto-attaches new tab`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/opener-page', `<title>Opener</title><body><button onclick="window.open('${server.PREFIX}opened-page', '_blank', 'noopener')">open</button></body>`, 'text/html');
+  server.setContent('/opened-page', '<title>Opened</title><body>Opened content</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + 'opener-page' },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  expect(await navigateResponse).toHaveResponse({
+    snapshot: expect.stringContaining('open'),
+  });
+
+  // Click the button that calls window.open.
+  await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'open', ref: 'e2' },
+  });
+
+  // Wait for the new tab to appear in the list.
+  await expect.poll(async () => {
+    const listResponse = await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'list' },
+    });
+    return (listResponse as any).content?.[0]?.text ?? '';
+  }).toContain('Opened');
+
+  const listResponse = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+
+  expect(listResponse).toHaveResponse({
+    result: expect.stringMatching(/- 0:.*\[Opener\].*\n- 1:.*\[Opened\]/),
+  });
+});
+
+test(`browser_run_code can evaluate in a web worker`, async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/worker.js', `
+    self.onmessage = (e) => self.postMessage('echo:' + e.data);
+    self.workerName = 'mcp-worker';
+  `, 'application/javascript');
+  server.setContent('/worker-page', `
+    <title>WorkerPage</title>
+    <body>
+      <script>
+        window.__worker = new Worker('/worker.js');
+      </script>
+    </body>
+  `, 'text/html');
+
+  const browserContext = await browserWithExtension.launch();
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  const navigateResponse = client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + 'worker-page' },
+  });
+
+  const selectorPage = await confirmationPagePromise;
+  await selectorPage.locator('.tab-item', { hasText: 'Playwright MCP extension' }).getByRole('button', { name: 'Connect' }).click();
+
+  await navigateResponse;
+
+  const runCodeResponse = await client.callTool({
+    name: 'browser_run_code',
+    arguments: {
+      code: `async (page) => {
+        const worker = page.workers().length ? page.workers()[0] : await page.waitForEvent('worker');
+        return await worker.evaluate(() => self.workerName);
+      }`,
+    },
+  });
+
+  expect(runCodeResponse).toHaveResponse({
+    result: expect.stringContaining('mcp-worker'),
+  });
+
+  // Open a second page with its own worker via browser_tabs new and verify
+  // that worker eval works in that tab too. This exercises child CDP sessions
+  // (the worker session) on a non-first tab — the relay must route them to
+  // the correct tab rather than always falling back to the first one.
+  server.setContent('/worker2.js', `
+    self.workerName = 'mcp-worker-2';
+  `, 'application/javascript');
+  server.setContent('/worker-page-2', `
+    <title>WorkerPage2</title>
+    <body>
+      <script>
+        window.__worker = new Worker('/worker2.js');
+      </script>
+    </body>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new', url: server.PREFIX + 'worker-page-2' },
+  });
+
+  const runCodeResponse2 = await client.callTool({
+    name: 'browser_run_code',
+    arguments: {
+      code: `async (page) => {
+        const worker = page.workers().length ? page.workers()[0] : await page.waitForEvent('worker');
+        return await worker.evaluate(() => self.workerName);
+      }`,
+    },
+  });
+
+  expect(runCodeResponse2).toHaveResponse({
+    result: expect.stringContaining('mcp-worker-2'),
+  });
+});
+
 test(`snapshot of an existing page`, async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 

--- a/packages/playwright-mcp/cli.js
+++ b/packages/playwright-mcp/cli.js
@@ -16,17 +16,17 @@
  */
 
 const { program } = require('playwright-core/lib/utilsBundle');
-const { decorateMCPCommand } = require('playwright-core/lib/tools/mcp/program');
+const { tools, libCli } = require('playwright-core/lib/coreBundle');
 
 if (process.argv.includes('install-browser')) {
   const argv = process.argv.map(arg => arg === 'install-browser' ? 'install' : arg);
-  const { program: mainProgram } = require('playwright-core/lib/cli/program');
-  mainProgram.parse(argv);
+  libCli.decorateProgram(program);
+  void program.parseAsync(argv);
   return;
 }
 
 const packageJSON = require('./package.json');
 const p = program.version('Version ' + packageJSON.version).name('Playwright MCP');
-decorateMCPCommand(p, packageJSON.version)
+tools.decorateMCPCommand(p, packageJSON.version);
 
 void program.parseAsync(process.argv);

--- a/packages/playwright-mcp/index.js
+++ b/packages/playwright-mcp/index.js
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 
-const { createConnection } = require('playwright-core/lib/tools/exports');
-module.exports = { createConnection };
+const { tools } = require('playwright-core/lib/coreBundle');
+module.exports = { createConnection: tools.createConnection };

--- a/packages/playwright-mcp/package.json
+++ b/packages/playwright-mcp/package.json
@@ -33,8 +33,8 @@
     }
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1775258971000",
-    "playwright-core": "1.60.0-alpha-1775258971000"
+    "playwright": "1.60.0-alpha-1775674864000",
+    "playwright-core": "1.60.0-alpha-1775674864000"
   },
   "bin": {
     "playwright-mcp": "cli.js"

--- a/packages/playwright-mcp/tests/fixtures.ts
+++ b/packages/playwright-mcp/tests/fixtures.ts
@@ -207,7 +207,7 @@ async function createTransport(args: string[], cwd: string, mcpMode: TestOptions
     stderr: 'pipe',
     env: {
       ...process.env,
-      DEBUG: 'pw:mcp:test',
+      DEBUG: process.env.PWMCP_DEBUG ? 'pw:mcp*' : 'pw:mcp:test',
       DEBUG_COLORS: '0',
       DEBUG_HIDE_DATE: '1',
       PWMCP_PROFILES_DIR_FOR_TEST: profilesDir,

--- a/packages/playwright-mcp/update-readme.js
+++ b/packages/playwright-mcp/update-readme.js
@@ -20,7 +20,7 @@ const fs = require('fs')
 const path = require('path')
 const { execSync } = require('child_process');
 
-const { browserTools } = require('playwright-core/lib/tools/exports');
+const { tools } = require('playwright-core/lib/coreBundle');
 
 const capabilities = /** @type {Record<string, string>} */ ({
   'core-navigation': 'Core automation',
@@ -38,7 +38,7 @@ const capabilities = /** @type {Record<string, string>} */ ({
 });
 
 const knownCapabilities = new Set(Object.keys(capabilities));
-const unknownCapabilities = [...new Set(browserTools.map(tool => tool.capability))].filter(cap => !knownCapabilities.has(cap));
+const unknownCapabilities = [...new Set(tools.browserTools.map(tool => tool.capability))].filter(cap => !knownCapabilities.has(cap));
 if (unknownCapabilities.length)
   throw new Error(`Unknown tool capabilities: ${unknownCapabilities.join(', ')}. Please update the capabilities map in ${path.basename(__filename)}.`);
 
@@ -46,9 +46,9 @@ if (unknownCapabilities.length)
 const toolsByCapability = {};
 for (const capability of Object.keys(capabilities)) {
   const title = capabilityTitle(capability);
-  let tools = browserTools.filter(tool => tool.capability === capability && !tool.skillOnly);
-  tools = (toolsByCapability[title] || []).concat(tools);
-  toolsByCapability[title] = tools;
+  let filteredTools = tools.browserTools.filter(tool => tool.capability === capability && !tool.skillOnly);
+  filteredTools = (toolsByCapability[title] || []).concat(filteredTools);
+  toolsByCapability[title] = filteredTools;
 }
 for (const [, tools] of Object.entries(toolsByCapability))
   tools.sort((a, b) => a.schema.name.localeCompare(b.schema.name));


### PR DESCRIPTION
## Summary
- Bump the extension-bridge protocol to v2 and make the cdpRelay the single owner of CDP session orchestration
- Extension exposes a thin `chrome.*` RPC (`chrome.debugger.attach/detach/sendCommand`, `chrome.tabs.create`) plus `extension.selectTab` for the initial tab pick
- cdpRelay assigns a relay sessionId per tab, dispatches `Target.attachedToTarget`/`detachedFromTarget` to Playwright, handles `Target.createTarget` by creating a chrome tab via the extension, and auto-attaches popups opened by a controlled tab
- Child CDP sessions (workers, oopifs) are tracked per tab so they route to the correct `chrome.debugger` session
- Protocol v1 (`attachToTab` / `forwardCDPCommand`) is still supported by the extension for older MCP clients; will be removed later
- Status page lists every connected tab; the connect dialog still selects a single initial tab
- Adds a backwards-compatibility test suite under `packages/extension/protocol-v1-compat/` that runs the extension against the published `@playwright/mcp@0.0.70` (protocol v1 client) to verify the new extension still serves v1 clients. Wired into CI on macOS.
