### PR TITLE
Honor context options for isolated CDP sessions

### DIFF
--- a/src/browserContextFactory.ts
+++ b/src/browserContextFactory.ts
@@ -125,7 +125,7 @@ class CdpContextFactory extends BaseContextFactory {
   }
 
   protected override async _doCreateContext(browser: playwright.Browser): Promise<playwright.BrowserContext> {
-    return this.browserConfig.isolated ? await browser.newContext() : browser.contexts()[0];
+    return this.browserConfig.isolated ? await browser.newContext(this.browserConfig.contextOptions) : browser.contexts()[0];
   }
 }
 

--- a/tests/cdp.spec.ts
+++ b/tests/cdp.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
 import url from 'node:url';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -57,6 +58,40 @@ test('cdp server reuse tab', async ({ cdpServer, startClient, server }) => {
 \`\`\`yaml
 - generic [active] [ref=e1]: Hello, world!
 \`\`\``),
+  });
+});
+
+test('cdp server honors storage state for isolated contexts', async ({ cdpServer, startClient, server }, testInfo) => {
+  const storageStatePath = testInfo.outputPath('cdp-storage-state.json');
+  await fs.promises.writeFile(storageStatePath, JSON.stringify({
+    origins: [
+      {
+        origin: server.PREFIX,
+        localStorage: [{ name: 'test', value: 'session-value' }],
+      },
+    ],
+  }));
+
+  server.setContent('/', `
+    <body>
+    </body>
+    <script>
+      document.body.textContent = 'Storage: ' + localStorage.getItem('test');
+    </script>
+  `, 'text/html');
+
+  await cdpServer.start();
+  const { client } = await startClient({ args: [
+    `--cdp-endpoint=${cdpServer.endpoint}`,
+    '--isolated',
+    `--storage-state=${storageStatePath}`,
+  ] });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    pageState: expect.stringContaining(`Storage: session-value`),
   });
 });
 


### PR DESCRIPTION
## Summary
- pass `browserConfig.contextOptions` when creating isolated CDP contexts
- add a regression test covering `--cdp-endpoint + --isolated + --storage-state`

## Why
`--storage-state` and other context options are already respected for launched isolated contexts, but CDP-attached isolated contexts were calling `browser.newContext()` without the configured options. That makes `--isolated` behave inconsistently between launch and CDP modes.

## Proof
- added `cdp server honors storage state for isolated contexts` in `tests/cdp.spec.ts`
- ran:
  - `npx playwright test tests/cdp.spec.ts --project=chrome -g 'cdp server honors storage state for isolated contexts'`
