### PR TITLE
feat(extension): sync tab group membership with MCP connection

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -202,6 +202,19 @@ class TabShareExtension {
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
     if (this._connectedTabIds.has(tabId))
       void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
+
+    if (!this._activeConnection || changeInfo.groupId === undefined)
+      return;
+    // Ignore the extension's own UI tabs (connect/status pages) — those get added
+    // to the group for visual grouping, not because they should be controlled.
+    if (tab.url?.startsWith(chrome.runtime.getURL('')))
+      return;
+    const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;
+    const isConnected = this._connectedTabIds.has(tabId);
+    if (inOurGroup && !isConnected)
+      void this._activeConnection.attachTab(tabId);
+    else if (!inOurGroup && isConnected)
+      void this._activeConnection.detachTab(tabId);
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -96,6 +96,46 @@ export class RelayConnection {
     this._onClose();
   }
 
+  // Simulates a "new tab opened" event for a tab the user added to the group.
+  // The relay reacts by issuing chrome.debugger.attach, which flows through
+  // the normal command path and fires ontabattached.
+  async attachTab(tabId: number): Promise<void> {
+    if (this._closed || this._protocolVersion !== 2)
+      return;
+    if (this._attachedTabs.has(tabId))
+      return;
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      this._sendMessage({ method: 'chrome.tabs.onCreated', params: [tab] });
+    } catch (error: any) {
+      debugLog('Error requesting attach for tab:', error);
+    }
+  }
+
+  // Simulates a "tab closed" event for a tab the user removed from the group.
+  // chrome.debugger.detach does not fire onDetach for the caller, so we do the
+  // bookkeeping and notify the relay ourselves.
+  async detachTab(tabId: number): Promise<void> {
+    if (this._closed)
+      return;
+    if (!this._attachedTabs.has(tabId))
+      return;
+    try {
+      await chrome.debugger.detach({ tabId });
+    } catch (error: any) {
+      debugLog('Error detaching tab:', error);
+    }
+    this._attachedTabs.delete(tabId);
+    this.ontabdetached?.(tabId);
+    if (this._protocolVersion === 2) {
+      this._sendMessage({
+        method: 'chrome.debugger.onDetach',
+        params: [{ tabId }, 'target_closed'],
+      });
+    }
+    this._checkLastTabDetached();
+  }
+
   private _installEventForwarders(): void {
     for (const { fullMethod } of CHROME_EVENTS) {
       const target = this._resolveChromeMember(fullMethod);

--- a/packages/extension/tests/extension.spec.ts
+++ b/packages/extension/tests/extension.spec.ts
@@ -508,6 +508,99 @@ test.describe('tab grouping', () => {
     expect(connectedGroupId).toBe(connectGroupId);
   });
 
+  test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
+    test.skip(protocolVersion === 1, 'Multi-tab not supported in protocol v1');
+
+    server.setContent('/extra', '<title>Extra</title><body>Extra content</body>', 'text/html');
+
+    const browserContext = await browserWithExtension.launch();
+
+    const page = await browserContext.newPage();
+    await page.goto(server.HELLO_WORLD);
+
+    const extraPage = await browserContext.newPage();
+    await extraPage.goto(server.PREFIX + 'extra');
+
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+    const connectPagePromise = browserContext.waitForEvent('page', p =>
+      p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+
+    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+    await navigatePromise;
+
+    // Drag the extra tab into the Playwright group — this should auto-attach it.
+    await connectPage.evaluate(async (targetUrl: string) => {
+      const chrome = (window as any).chrome;
+      const connectTab = await chrome.tabs.getCurrent();
+      const [extra] = await chrome.tabs.query({ url: targetUrl });
+      await chrome.tabs.group({ groupId: connectTab.groupId, tabIds: [extra.id] });
+    }, server.PREFIX + 'extra');
+
+    await expect.poll(async () => {
+      const r = await client.callTool({ name: 'browser_tabs', arguments: { action: 'list' } });
+      return (r as any).content?.[0]?.text ?? '';
+    }).toContain('Extra');
+  });
+
+  test('tab removed from group gets auto-detached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
+    test.skip(protocolVersion === 1, 'Multi-tab not supported in protocol v1');
+
+    server.setContent('/second', '<title>Second</title><body>Second</body>', 'text/html');
+
+    const browserContext = await browserWithExtension.launch();
+    const page = await browserContext.newPage();
+    await page.goto(server.HELLO_WORLD);
+
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+    const connectPagePromise = browserContext.waitForEvent('page', p =>
+      p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+
+    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+    await navigatePromise;
+
+    // Create a second tab via the client — it will be attached and added to the group.
+    await client.callTool({ name: 'browser_tabs', arguments: { action: 'new', url: server.PREFIX + 'second' } });
+
+    // The second tab is attached (has the connected badge).
+    await expect.poll(async () => {
+      return connectPage.evaluate(async (targetUrl: string) => {
+        const chrome = (window as any).chrome;
+        const [t] = await chrome.tabs.query({ url: targetUrl });
+        if (!t?.id)
+          return '';
+        return await chrome.action.getBadgeText({ tabId: t.id });
+      }, server.PREFIX + 'second');
+    }).toBe('✓');
+
+    // Ungroup the second tab — this should auto-detach it.
+    await connectPage.evaluate(async (targetUrl: string) => {
+      const chrome = (window as any).chrome;
+      const [second] = await chrome.tabs.query({ url: targetUrl });
+      await chrome.tabs.ungroup([second.id]);
+    }, server.PREFIX + 'second');
+
+    // The badge should be cleared, indicating the tab was detached.
+    await expect.poll(async () => {
+      return connectPage.evaluate(async (targetUrl: string) => {
+        const chrome = (window as any).chrome;
+        const [t] = await chrome.tabs.query({ url: targetUrl });
+        if (!t?.id)
+          return '';
+        return await chrome.action.getBadgeText({ tabId: t.id });
+      }, server.PREFIX + 'second');
+    }).toBe('');
+  });
+
   test('connected tab is removed from group on disconnect', async ({ browserWithExtension, startClient, server }) => {
     const browserContext = await browserWithExtension.launch();
 


### PR DESCRIPTION
Dragging a tab into the Playwright group auto-attaches it (like a new tab opened), and dragging one out auto-detaches it (like the tab was closed).