### PR TITLE
chore(extension): rename Playwright MCP Bridge to Playwright Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Playwright MCP server supports following arguments. They can be provided in the 
 | --console-level <level> | level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.<br>*env* `PLAYWRIGHT_MCP_CONSOLE_LEVEL` |
 | --device <device> | device to emulate, for example: "iPhone 15"<br>*env* `PLAYWRIGHT_MCP_DEVICE` |
 | --executable-path <path> | path to the browser executable.<br>*env* `PLAYWRIGHT_MCP_EXECUTABLE_PATH` |
-| --extension | Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright MCP Bridge" browser extension to be installed.<br>*env* `PLAYWRIGHT_MCP_EXTENSION` |
+| --extension | Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright Extension" to be installed.<br>*env* `PLAYWRIGHT_MCP_EXTENSION` |
 | --endpoint <endpoint> | Bound browser endpoint to connect to.<br>*env* `PLAYWRIGHT_MCP_ENDPOINT` |
 | --grant-permissions <permissions...> | List of permissions to grant to the browser context, for example "geolocation", "clipboard-read", "clipboard-write".<br>*env* `PLAYWRIGHT_MCP_GRANT_PERMISSIONS` |
 | --headless | run browser in headless mode, headed by default<br>*env* `PLAYWRIGHT_MCP_HEADLESS` |
@@ -594,7 +594,7 @@ npx @playwright/mcp@latest --config path/to/config.json
   /**
    * Connect to a running browser instance (Edge/Chrome only). If specified, `browser`
    * config is ignored.
-   * Requires the "Playwright MCP Bridge" browser extension to be installed.
+   * Requires the "Playwright Extension" to be installed.
    */
   extension?: boolean;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
-        "@playwright/test": "1.60.0-alpha-1776364014000",
+        "@playwright/test": "1.60.0-alpha-1776382637000",
         "@types/node": "^24.3.0"
       }
     },
@@ -854,13 +854,13 @@
       "link": true
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-1776364014000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1776364014000.tgz",
-      "integrity": "sha512-PCbnz2l1ofshJ3iQVKbFfcOKXdoFoWemOQZRfsiJv64LlrY92Icc9b12VUR+PBJbJ6WOYKCSw/VL80vI6BX3nw==",
+      "version": "1.60.0-alpha-1776382637000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-1776382637000.tgz",
+      "integrity": "sha512-iyjWZgX67WLcZ6428R02yBu1fJE/pJLpfnEuoyqqIX1LMWSGHYcT41bterRTK8gDHqNUgD0EBYHPYlYVzUAJsg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1776364014000"
+        "playwright": "1.60.0-alpha-1776382637000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2624,12 +2624,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1776364014000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1776364014000.tgz",
-      "integrity": "sha512-sye2A5tqjW22pNootcer2VxaWJtZX9nFi+OnCxHwjSOZ6ErQVkZyeqm5/p+9Sm8kPG0YBBNed0zKbn6hTUiIwQ==",
+      "version": "1.60.0-alpha-1776382637000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1776382637000.tgz",
+      "integrity": "sha512-UxfASt2/Y5m1CJgDVYnWOOOHaWrlcDXGRMhKaWTTTHobsAt1hTIOfuX/wT381ugvDq4GWroqmjMP3iYoZwt3lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1776364014000"
+        "playwright-core": "1.60.0-alpha-1776382637000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2646,9 +2646,9 @@
       "link": true
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1776364014000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1776364014000.tgz",
-      "integrity": "sha512-XiARvib3WBBR/yg7lQdobbP7V0jiX+8aGkLOtXB1YIM+XMTLJARcue7E5uNebGRlwQPdjTpBJTqTItFiQ/x46w==",
+      "version": "1.60.0-alpha-1776382637000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1776382637000.tgz",
+      "integrity": "sha512-y+e3G0UKCJUKZl5jlPWoBrM+5G8bfHb/4NXDv522eHQz19CO6QCUUi05BacH0/lGM8q5T1nqRSVx1QqpbLc4DA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3444,8 +3444,8 @@
       "version": "0.0.70",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1776364014000",
-        "playwright-core": "1.60.0-alpha-1776364014000"
+        "playwright": "1.60.0-alpha-1776382637000",
+        "playwright-core": "1.60.0-alpha-1776382637000"
       },
       "bin": {
         "playwright-mcp": "cli.js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "@playwright/test": "1.60.0-alpha-1776364014000",
+    "@playwright/test": "1.60.0-alpha-1776382637000",
     "@types/node": "^24.3.0"
   }
 }

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -12,7 +12,7 @@ The Playwright MCP Chrome Extension allows you to connect to pages in your exist
 
 ### Install the Extension
 
-Install [Playwright MCP Bridge](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
+Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
 
 ### Configure Playwright MCP server
 

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Playwright MCP Bridge",
+  "name": "Playwright Extension",
   "version": "0.1.0",
-  "description": "Share browser tabs with Playwright MCP server",
+  "description": "Connect your browser to AI agents through Playwright MCP server and CLI. Enables AI-driven web testing, debugging, and automation.",
   "permissions": [
     "debugger",
     "activeTab",
@@ -17,7 +17,7 @@
     "type": "module"
   },
   "action": {
-    "default_title": "Playwright MCP Bridge",
+    "default_title": "Playwright Extension",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -20,7 +20,7 @@
     "watch": "tsc --watch --project . & tsc --watch --project tsconfig.ui.json & vite build --watch & vite build --watch --config vite.sw.config.mts",
     "test": "playwright test",
     "lint": "tsc --project .",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist test-results"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.315",

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -134,7 +134,7 @@ class TabShareExtension {
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
         this._connectedTabIds.add(newTabId);
-        void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
+        void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' });
         void this._addTabToGroup(newTabId);
       };
       this._activeConnection.ontabdetached = (removedTabId: number) => {
@@ -147,7 +147,7 @@ class TabShareExtension {
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
-      debugLog(`Connected to MCP bridge`);
+      debugLog(`Connected to Playwright client`);
     } catch (error: any) {
       this._connectedTabIds.clear();
       debugLog(`Failed to connect tab ${tabId}:`, error.message);

--- a/packages/extension/src/ui/authToken.tsx
+++ b/packages/extension/src/ui/authToken.tsx
@@ -21,17 +21,12 @@ import './authToken.css';
 
 export const AuthTokenSection: React.FC<{}> = ({}) => {
   const [authToken, setAuthToken] = useState<string>(getOrCreateAuthToken);
-  const [isExampleExpanded, setIsExampleExpanded] = useState<boolean>(false);
 
   const onRegenerateToken = useCallback(() => {
     const newToken = generateAuthToken();
     localStorage.setItem('auth-token', newToken);
     setAuthToken(newToken);
   }, []);
-
-  const toggleExample = useCallback(() => {
-    setIsExampleExpanded(!isExampleExpanded);
-  }, [isExampleExpanded]);
 
   return (
     <div className='auth-token-section'>
@@ -43,53 +38,12 @@ export const AuthTokenSection: React.FC<{}> = ({}) => {
         <button className='auth-token-refresh' title='Generate new token' aria-label='Generate new token'onClick={onRegenerateToken}>{icons.refresh()}</button>
         <CopyToClipboard value={authTokenCode(authToken)} />
       </div>
-
-      <div className='auth-token-example-section'>
-        <button
-          className='auth-token-example-toggle'
-          onClick={toggleExample}
-          aria-expanded={isExampleExpanded}
-          title={isExampleExpanded ? 'Hide example config' : 'Show example config'}
-        >
-          <span className={`auth-token-chevron ${isExampleExpanded ? 'expanded' : ''}`}>
-            {icons.chevronDown()}
-          </span>
-          Example MCP server configuration
-        </button>
-
-        {isExampleExpanded && (
-          <div className='auth-token-example-content'>
-            <div className='auth-token-example-description'>
-              Add this configuration to your MCP client (e.g., VS Code) to connect to the Playwright MCP Bridge:
-            </div>
-            <div className='auth-token-example-config'>
-              <code className='auth-token-example-code'>{exampleConfig(authToken)}</code>
-              <CopyToClipboard value={exampleConfig(authToken)} />
-            </div>
-          </div>
-        )}
-      </div>
     </div>
   );
 };
 
 function authTokenCode(authToken: string) {
   return `PLAYWRIGHT_MCP_EXTENSION_TOKEN=${authToken}`;
-}
-
-function exampleConfig(authToken: string) {
-  return `{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest", "--extension"],
-      "env": {
-        "PLAYWRIGHT_MCP_EXTENSION_TOKEN":
-          "${authToken}"
-      }
-    }
-  }
-}`;
 }
 
 function generateAuthToken(): string {

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -67,7 +67,7 @@ const ConnectApp: React.FC = () => {
         setClientInfo(info);
         setStatus({
           type: 'connecting',
-          message: `"${info}" is trying to connect to the Playwright extension.`
+          message: `"${info}" is trying to connect to the Playwright Extension.`
         });
       } catch (e) {
         setStatus({ type: 'error', message: 'Failed to parse client version.' });
@@ -216,7 +216,7 @@ const ConnectApp: React.FC = () => {
         {showTabList && (
           <div>
             <div className='tab-section-title'>
-              Select page to expose to MCP server:
+              Select the default tab for this connection:
             </div>
             <div>
               {tabs.map(tab => (
@@ -244,7 +244,7 @@ const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensio
   return (
     <div>
       Playwright MCP version trying to connect requires newer extension version (current version: {extensionVersion}).{' '}
-      Update <a href={chromeWebStoreUrl} target='_blank' rel='noopener noreferrer'>Playwright MCP Bridge</a> from the Chrome Web Store to the latest version.{' '}
+      Update <a href={chromeWebStoreUrl} target='_blank' rel='noopener noreferrer'>Playwright Extension</a> from the Chrome Web Store to the latest version.{' '}
       See <a href={readmeUrl} target='_blank' rel='noopener noreferrer'>installation instructions</a> for more details.
     </div>
   );

--- a/packages/extension/src/ui/status.html
+++ b/packages/extension/src/ui/status.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Playwright MCP Bridge Status</title>
+  <title>Playwright Extension Status</title>
   <link rel="stylesheet" href="connect.css">
 </head>
 <body>

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -64,7 +64,7 @@ const StatusApp: React.FC = () => {
         {connectedTabs.length > 0 ? (
           <div>
             <div className='tab-section-title'>
-              {connectedTabs.length === 1 ? 'Page connected to MCP client:' : 'Pages connected to MCP client:'}
+              {connectedTabs.length === 1 ? 'Page connected to Playwright client:' : 'Pages connected to Playwright client:'}
             </div>
             <div>
               {connectedTabs.map((tab, index) => (

--- a/packages/extension/tests/extension.spec.ts
+++ b/packages/extension/tests/extension.spec.ts
@@ -203,7 +203,7 @@ test(`extension not installed timeout`, async ({ startExtensionClient, server })
     name: 'browser_navigate',
     arguments: { url: server.HELLO_WORLD },
   })).toHaveResponse({
-    error: expect.stringContaining('Extension connection timeout. Make sure the "Playwright MCP Bridge" extension is installed.'),
+    error: expect.stringMatching(/Extension connection timeout. Make sure the "Playwright.* is installed\./),
     isError: true,
   });
 

--- a/packages/playwright-mcp/config.d.ts
+++ b/packages/playwright-mcp/config.d.ts
@@ -101,7 +101,7 @@ export type Config = {
   /**
    * Connect to a running browser instance (Edge/Chrome only). If specified, `browser`
    * config is ignored.
-   * Requires the "Playwright MCP Bridge" browser extension to be installed.
+   * Requires the "Playwright Extension" to be installed.
    */
   extension?: boolean;
 

--- a/packages/playwright-mcp/package.json
+++ b/packages/playwright-mcp/package.json
@@ -33,8 +33,8 @@
     }
   },
   "dependencies": {
-    "playwright": "1.60.0-alpha-1776364014000",
-    "playwright-core": "1.60.0-alpha-1776364014000"
+    "playwright": "1.60.0-alpha-1776382637000",
+    "playwright-core": "1.60.0-alpha-1776382637000"
   },
   "bin": {
     "playwright-mcp": "cli.js"


### PR DESCRIPTION
## Summary
- Rename extension from "Playwright MCP Bridge" to "Playwright Extension" across manifest, UI, docs, and config
- Update manifest description to use full 132-char budget for Chrome Web Store featured badge
- Remove example MCP config section from auth token page
- Update test assertion to use regex for forward-compatible error matching