### PR TITLE
fix(extension): throw clear error for tab creation in protocol v1

### DIFF
--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -274,6 +274,8 @@ export class RelayConnection {
     }
     if (message.method === 'forwardCDPCommand') {
       const { sessionId, method, params } = message.params;
+      if (method === 'Target.createTarget')
+        throw new Error('Tab creation is not supported yet. Update Playwright MCP or CLI to the latest version.');
       const tabId = [...this._attachedTabs][0];
       if (tabId === undefined)
         throw new Error('No tab is connected');


### PR DESCRIPTION
## Summary
- When an old CLI sends `Target.createTarget` via `forwardCDPCommand` (protocol v1), the extension now throws a clear error suggesting to update Playwright MCP or CLI, instead of causing a cryptic `_page` failure.
- This allows pushing the extension update to guide users with older CLIs toward upgrading.