### PR TITLE
fix(extension): notify connect page when pending connection is closed

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -37,12 +37,11 @@ class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
   private _connectedTabIds: Set<number> = new Set();
   private _groupId: number | null = null;
-  private _pendingTabSelection = new Map<number, { connection: RelayConnection, timerId?: number }>();
+  private _pendingTabSelection = new Map<number, RelayConnection>();
 
   constructor() {
     chrome.tabs.onRemoved.addListener(this._onTabRemoved.bind(this));
     chrome.tabs.onUpdated.addListener(this._onTabUpdated.bind(this));
-    chrome.tabs.onActivated.addListener(this._onTabActivated.bind(this));
     chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     chrome.action.onClicked.addListener(this._onActionClicked.bind(this));
   }
@@ -93,11 +92,14 @@ class TabShareExtension {
 
       const connection = new RelayConnection(socket, protocolVersion);
       connection.onclose = () => {
-        debugLog('Connection closed');
-        this._pendingTabSelection.delete(selectorTabId);
-        // TODO: show error in the selector tab?
+        debugLog('Pending connection closed');
+        const existed = this._pendingTabSelection.delete(selectorTabId);
+        if (existed) {
+          chrome.tabs.sendMessage(selectorTabId, { type: 'pendingConnectionClosed' }).catch(() => {});
+          chrome.tabs.ungroup(selectorTabId).catch(() => {});
+        }
       };
-      this._pendingTabSelection.set(selectorTabId, { connection });
+      this._pendingTabSelection.set(selectorTabId, connection);
       await this._addTabToGroup(selectorTabId);
       debugLog(`Connected to MCP relay`);
     } catch (error: any) {
@@ -118,9 +120,9 @@ class TabShareExtension {
       await Promise.all([...this._connectedTabIds].map(id => this._updateBadge(id, { text: '' })));
       this._connectedTabIds.clear();
 
-      this._activeConnection = this._pendingTabSelection.get(selectorTabId)?.connection;
+      this._activeConnection = this._pendingTabSelection.get(selectorTabId);
       if (!this._activeConnection)
-        throw new Error('No active MCP relay connection');
+        throw new Error('Pending client connection closed');
       this._pendingTabSelection.delete(selectorTabId);
 
       this._activeConnection.setSelectedTab(tabId);
@@ -167,7 +169,7 @@ class TabShareExtension {
   }
 
   private async _onTabRemoved(tabId: number): Promise<void> {
-    const pendingConnection = this._pendingTabSelection.get(tabId)?.connection;
+    const pendingConnection = this._pendingTabSelection.get(tabId);
     if (pendingConnection) {
       this._pendingTabSelection.delete(tabId);
       pendingConnection.close('Browser tab closed');
@@ -176,27 +178,6 @@ class TabShareExtension {
     // Tab removal is handled by RelayConnection (ontabdetached / onclose).
     // No action needed here — the relay detects it via chrome.tabs.onRemoved
     // and chrome.debugger.onDetach listeners.
-  }
-
-  private _onTabActivated(activeInfo: chrome.tabs.TabActiveInfo) {
-    for (const [tabId, pending] of this._pendingTabSelection) {
-      if (tabId === activeInfo.tabId) {
-        if (pending.timerId) {
-          clearTimeout(pending.timerId);
-          pending.timerId = undefined;
-        }
-        continue;
-      }
-      if (!pending.timerId) {
-        pending.timerId = setTimeout(() => {
-          const existed = this._pendingTabSelection.delete(tabId);
-          if (existed) {
-            pending.connection.close('Tab has been inactive for 5 seconds');
-            chrome.tabs.sendMessage(tabId, { type: 'connectionTimeout' });
-          }
-        }, 5000);
-      }
-    }
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -147,25 +147,27 @@ const ConnectApp: React.FC = () => {
       });
 
       if (response?.success) {
-        setStatus({ type: 'connected', message: `MCP client "${clientInfo}" connected.` });
+        setStatus({ type: 'connected', message: `"${clientInfo}" connected.` });
       } else {
         setStatus({
           type: 'error',
-          message: response?.error || `MCP client "${clientInfo}" failed to connect.`
+          message: response?.error || `"${clientInfo}" failed to connect.`
         });
       }
     } catch (e) {
       setStatus({
         type: 'error',
-        message: `MCP client "${clientInfo}" failed to connect: ${e}`
+        message: `"${clientInfo}" failed to connect: ${e}`
       });
     }
   }, [clientInfo, mcpRelayUrl]);
 
   useEffect(() => {
     const listener = (message: any) => {
-      if (message.type === 'connectionTimeout')
-        handleReject('Connection timed out.');
+      if (message.type === 'pendingConnectionClosed') {
+        handleReject('Pending client connection closed.');
+        document.title = 'Playwright Extension';
+      }
     };
     chrome.runtime.onMessage.addListener(listener);
     return () => {

--- a/packages/extension/tests/extension.spec.ts
+++ b/packages/extension/tests/extension.spec.ts
@@ -309,3 +309,35 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
 });
+
+test(`pending connection closed when client disconnects`, async ({ startExtensionClient, server }) => {
+  const { browserContext, client } = await startExtensionClient();
+
+  const confirmationPagePromise = browserContext.waitForEvent('page', page => {
+    return page.url().startsWith(`chrome-extension://${extensionId}/connect.html`);
+  });
+
+  client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  }).catch(() => {});
+
+  const selectorPage = await confirmationPagePromise;
+  // Wait for the tab list to appear so we know the relay connection is established.
+  await selectorPage.locator('.tab-item').first().waitFor();
+
+  // Close the MCP client, which tears down the relay WebSocket.
+  await client.close();
+
+  await expect(selectorPage.locator('.status-banner')).toContainText('Pending client connection closed.');
+  await expect(selectorPage).toHaveTitle('Playwright Extension');
+
+  // The connect tab should be removed from the Playwright group.
+  await expect.poll(async () => {
+    return selectorPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const tab = await chrome.tabs.getCurrent();
+      return tab?.groupId ?? -1;
+    });
+  }).toBe(-1);
+});


### PR DESCRIPTION
Replace the tab-inactivity timeout with a simpler approach: when the relay WebSocket closes while the connect page is still showing the tab picker, send a `pendingConnectionClosed` message and remove the tab from the Playwright group. Also guard `Target.createTarget` in the extension's `forwardCDPCommand` handler for old CLI clients.