### PR TITLE
fix(extension): don't add status page to tab group when not connected

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -241,12 +241,10 @@ class TabShareExtension {
   }
 
   private async _onActionClicked(): Promise<void> {
-    const tab = await chrome.tabs.create({
+    await chrome.tabs.create({
       url: chrome.runtime.getURL('status.html'),
       active: true
     });
-    if (tab.id)
-      await this._addTabToGroup(tab.id);
   }
 
   private async _disconnect(): Promise<void> {


### PR DESCRIPTION
## Summary
- Stop adding the status page to the Playwright tab group when opened via the extension icon click, since no client is actually connected to it.

