### PR TITLE
feat(mcp): add recordVideo config option and fix roll.js source path

### DIFF
--- a/packages/playwright-mcp/config.d.ts
+++ b/packages/playwright-mcp/config.d.ts
@@ -96,6 +96,13 @@ export type Config = {
      * The scripts will be evaluated in every page before any of the page's scripts.
      */
     initScript?: string[];
+
+    /**
+     * Directory to save video recordings to. When set, video recording is
+     * automatically enabled for every browser context. Use the
+     * `browser_save_recording` tool to retrieve the recorded file path.
+     */
+    recordVideo?: string;
   },
 
   /**

--- a/roll.js
+++ b/roll.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 function copyConfig() {
-  const src = path.join(__dirname, '..', 'playwright', 'packages', 'playwright-core', 'src', 'tools', 'mcp', 'config.d.ts');
+  const src = path.join(__dirname, '..', 'playwright', 'packages', 'playwright', 'src', 'mcp', 'config.d.ts');
   const dst = path.join(__dirname, 'packages', 'playwright-mcp', 'config.d.ts');
   let content = fs.readFileSync(src, 'utf-8');
   content = content.replace(


### PR DESCRIPTION
## Summary

- Adds `browser.recordVideo?: string` to the public `Config` type in `config.d.ts` — a convenient shorthand that enables video recording for every browser context and sets the output directory. Use the `browser_save_recording` MCP tool to retrieve the recorded file path.
- Fixes the stale source path in `roll.js` that pointed to `playwright-core/src/tools/mcp/config.d.ts` (no longer exists); updated to the current location `playwright/src/mcp/config.d.ts` so future rolls sync correctly.

## Test plan

- [ ] Set `browser.recordVideo: "/tmp/recordings"` in a config file and verify video recording is enabled
- [ ] Run `node roll.js` and confirm it successfully copies `config.d.ts` from the correct path
- [ ] Call `browser_save_recording` after a session and confirm the file path is valid

Made with [Cursor](https://cursor.com)