### PR TITLE
docs: note chromium setup for linux arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ First, install the Playwright MCP server with your client.
 }
 ```
 
+If you're on Linux arm64, the Chrome channel may be unavailable. In that case,
+configure Playwright MCP to use `chromium` explicitly instead of `chrome`:
+
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--browser",
+        "chromium"
+      ]
+    }
+  }
+}
+```
+
 [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522playwright%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540playwright%252Fmcp%2540latest%2522%255D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522playwright%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540playwright%252Fmcp%2540latest%2522%255D%257D)
 
 <details>


### PR DESCRIPTION
## Summary
- document that Linux arm64 users may need to select chromium explicitly
- add a ready-to-copy MCP config example using --browser chromium

## Testing
- not run (README-only change)

Closes #1560