### PR TITLE
docs: add Windows Claude Code workaround for npx stdio failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ Use the Claude Code CLI to add the Playwright MCP server:
 ```bash
 claude mcp add playwright npx @playwright/mcp@latest
 ```
+
+On Windows, Claude Code may fail to connect to the MCP stdio transport when the server is launched through `npx` / `npx.cmd`, especially when you need extra arguments like `--cdp-endpoint`. In that case, install `@playwright/mcp` locally and point Claude Code at the package entrypoint with `node` instead of the batch wrapper:
+
+```json
+{
+  "playwright": {
+    "type": "stdio",
+    "command": "node",
+    "args": [
+      "C:\\path\\to\\your\\project\\node_modules\\@playwright\\mcp\\cli.js",
+      "--cdp-endpoint",
+      "http://127.0.0.1:9222"
+    ]
+  }
+}
+```
+
+This avoids the Windows `npx.cmd` wrapper and lets Claude Code attach cleanly over stdio.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- document a Windows-specific Claude Code workaround when stdio fails through npx or npx.cmd
- show a node plus cli.js configuration that still supports extra arguments like --cdp-endpoint

## Why
Some Windows Claude Code setups fail to connect to the Playwright MCP stdio transport when launched through the npx batch wrapper. Documenting the direct node entrypoint gives users a practical path forward.

Fixes #1540.