### PR TITLE
Clean up cliDaemon processes on MCP server exit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+const { spawnSync } = require('child_process');
 const { program } = require('playwright-core/lib/utilsBundle');
 const { tools, libCli } = require('playwright-core/lib/coreBundle');
 
@@ -23,6 +24,99 @@ if (process.argv.includes('install-browser')) {
   libCli.decorateProgram(program);
   void program.parseAsync(argv);
   return;
+}
+
+// Snapshot pre-existing playwright-core cliDaemon processes so that on exit
+// we only clean up daemons that were spawned during this MCP server's
+// lifetime. Without this cleanup, the cliDaemon (and its headless browser)
+// keeps running after the MCP wrapper exits because it is launched with
+// `detached: true` + `child.unref()` (see playwright-core's session.js).
+// MCP clients commonly hard-kill the wrapper process on session end (or just
+// close stdio), so signal forwarding alone does not survive that path.
+const DAEMON_CMDLINE_PATTERN = /\bnode\b.*\/cliDaemon\.js\b/;
+
+function snapshotDaemonPids() {
+  if (process.platform === 'win32')
+    return new Set();
+  try {
+    const result = spawnSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf8' });
+    if (result.status !== 0 || !result.stdout)
+      return new Set();
+    const pids = new Set();
+    for (const line of result.stdout.split('\n')) {
+      if (!DAEMON_CMDLINE_PATTERN.test(line))
+        continue;
+      const match = line.match(/^\s*(\d+)\b/);
+      if (match)
+        pids.add(parseInt(match[1], 10));
+    }
+    return pids;
+  } catch {
+    return new Set();
+  }
+}
+
+const initialDaemonPids = snapshotDaemonPids();
+let cleanupHasRun = false;
+
+function cleanupSpawnedDaemons({ blocking } = { blocking: false }) {
+  if (cleanupHasRun)
+    return;
+  cleanupHasRun = true;
+  const current = snapshotDaemonPids();
+  const ours = [];
+  for (const pid of current) {
+    if (!initialDaemonPids.has(pid))
+      ours.push(pid);
+  }
+  if (!ours.length)
+    return;
+  for (const pid of ours) {
+    try { process.kill(pid, 'SIGTERM'); } catch { /* already gone */ }
+  }
+  if (!blocking)
+    return;
+  // Give children up to ~500ms to die gracefully before SIGKILL.
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    let anyAlive = false;
+    for (const pid of ours) {
+      try { process.kill(pid, 0); anyAlive = true; break; } catch { /* dead */ }
+    }
+    if (!anyAlive)
+      return;
+    spawnSync(process.execPath, ['-e', 'setTimeout(()=>{},50)']); // ~50ms sleep
+  }
+  for (const pid of ours) {
+    try { process.kill(pid, 'SIGKILL'); } catch { /* dead */ }
+  }
+}
+
+function gracefulShutdown(signal) {
+  cleanupSpawnedDaemons({ blocking: true });
+  // Re-raise the signal with default handler so exit code reflects the signal.
+  process.exit(signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 0);
+}
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'])
+  process.on(signal, () => gracefulShutdown(signal));
+
+// 'exit' fires synchronously; only sync work allowed.
+process.on('exit', () => cleanupSpawnedDaemons({ blocking: false }));
+
+// MCP stdio transport: when the parent (e.g. an LLM client) closes stdin,
+// our process should treat that as a disconnect and shut down cleanly.
+// Without this, the wrapper can linger after the parent exits, and so can
+// any cliDaemon it spawned.
+//
+// HTTP mode (`--port`/`--host`) does not use stdin for transport; in that
+// mode the listener would fire spuriously when stdin is closed at startup,
+// so we only attach it in stdio mode.
+const isHttpMode = process.argv.some(a => a === '--port' || a.startsWith('--port=')
+    || a === '--host' || a.startsWith('--host='));
+if (!isHttpMode && process.stdin && !process.stdin.isTTY) {
+  process.stdin.once('end', () => gracefulShutdown('SIGTERM'));
+  process.stdin.once('close', () => gracefulShutdown('SIGTERM'));
 }
 
 const packageJSON = require('./package.json');


### PR DESCRIPTION
## Problem

When the MCP wrapper (`@playwright/mcp`) is killed by an MCP client — including via SIGKILL or simple stdio close — the `cliDaemon` it spawned stays alive forever, along with its headless browser. The daemon is reparented to init (PPID=1) and continues consuming RAM.

**Repro:**

1. Start any MCP client that talks to `npx @playwright/mcp@latest` over stdio.
2. Issue a tool call that opens a browser (e.g. `browser_navigate`).
3. Kill the wrapper: `pkill -9 -f '@playwright/mcp'`.
4. Observe: `pgrep -fa cliDaemon.js` still alive with `PPID=1`, plus headless Chrome.

I've personally hit cliDaemons surviving 2+ days after their MCP parent died, accumulating ~75 MB RAM each across long-lived shell sessions running multiple MCP clients.

## Root cause

`playwright-core/lib/tools/cli-client/session.js`'s `Session.startDaemon()` spawns the daemon with `detached: true` + `child.unref()`. SIGINT/SIGTERM forwarding handlers are removed once the daemon is up. From the wrapper's perspective, the daemon is intentionally orphaned for CLI persistence — but in MCP mode that lifecycle is wrong: when the MCP server exits, the daemon should go too.

## Fix

`cli.js` snapshots existing cliDaemon PIDs at startup, then registers signal/exit/stdin-EOF handlers that kill any *new* cliDaemon PIDs that appeared during this server's lifetime.

- **Diff-based snapshot** — never kills daemons started by other concurrent MCP servers, only ours.
- **Signal handlers** — SIGINT, SIGTERM, SIGHUP run blocking cleanup (SIGTERM → 500ms wait → SIGKILL).
- **Stdin EOF** — primary disconnect signal for MCP stdio transport. Skipped in HTTP mode (`--port`/`--host`).
- **Sync `exit` handler** — last-ditch fire-and-forget SIGTERM for paths where signals don't run.
- **Windows** — no-op (no PPID/pgid model in the same form).

## Why not fix in `playwright-core`

The orphan-on-MCP-exit behavior is specific to the MCP wrapper's lifecycle expectations. CLI users explicitly rely on the daemon outliving short-lived `pw cli ...` invocations. Adding cleanup logic here keeps the change scoped to the MCP server entry point and doesn't risk regressing CLI flows.

## Verification

```bash
# Build
node cli.js --version  # → "Version 0.0.71"

# Smoke test: stdin EOF triggers shutdown with exit 143 (SIGTERM)
node -e "const cp=require('child_process'); const p=cp.spawn('node',['./cli.js']); setTimeout(()=>p.stdin.end(),500); p.on('exit',(c,s)=>console.log(c,s));"
# → 143 null
```

I'd happily add a Playwright-test integration spec under `tests/` that opens a daemon via an MCP tool call, closes stdin, then asserts `pgrep` no longer finds the daemon — let me know if that's wanted as part of this PR or a follow-up.