### PR TITLE
chore: mark v0.0.72

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/mcp",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/mcp",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0-alpha-1777566615000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/mcp",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "Playwright Tools for MCP",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps `@playwright/mcp` to v0.0.72.