### PR TITLE
feat(publish): allow manual workflow_dispatch for MCP Registry publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,14 @@ jobs:
       - run: npm publish
 
   publish-mcp-release-registry:
-    if: github.event_name == 'release'
+    # Runs on release (after npm publish succeeds) or via manual workflow_dispatch
+    # (e.g. to retroactively publish a version, in which case publish-mcp-release-npm
+    # is skipped — the always() + result check lets this job still run).
+    if: |
+      always() &&
+      (github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
+      needs.publish-mcp-release-npm.result != 'failure' &&
+      needs.publish-mcp-release-npm.result != 'cancelled'
     needs: publish-mcp-release-npm
     runs-on: ubuntu-latest
     permissions:

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/microsoft/playwright-mcp",
     "source": "github"
   },
-  "version": "0.0.71",
+  "version": "0.0.72",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@playwright/mcp",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "transport": {
         "type": "stdio"
       }
@@ -20,7 +20,7 @@
       "registryType": "oci",
       "registryBaseUrl": "https://playwright.azurecr.io",
       "identifier": "public/playwright/mcp",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Expands the gate on `publish-mcp-release-registry` so it also runs on `workflow_dispatch`. Lets us retroactively publish a previously-released version (or rerun a failed publish) from the Actions tab without re-running the npm release.
- Bumps `server.json` to `0.0.72` to match `package.json`. The validation step added in #1585 would otherwise fail the next release, since `mark v0.0.72` (#1584) landed before #1585 — `server.json` was committed at `0.0.71`.

## Mechanics
The job still `needs: publish-mcp-release-npm` so on a real `release` event it correctly waits for npm to publish first. On `workflow_dispatch`, the npm job is skipped (its own `if` is `release`-only), and `if: always() && needs.*.result != 'failure'/'cancelled'` lets the registry job run anyway.

## Follow-up
Once merged, this enables a manual one-shot of v0.0.72 to the registry via the Actions tab.

Follow-up to #1585.
Reference https://github.com/microsoft/playwright-mcp/issues/1477