### PR TITLE
fix(publish): drop OCI package entry from server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -15,15 +15,6 @@
       "transport": {
         "type": "stdio"
       }
-    },
-    {
-      "registryType": "oci",
-      "registryBaseUrl": "https://playwright.azurecr.io",
-      "identifier": "public/playwright/mcp",
-      "version": "0.0.72",
-      "transport": {
-        "type": "stdio"
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
The first dispatch run after #1586 ([failed run](https://github.com/microsoft/playwright-mcp/actions/runs/25195774292/job/73875880165)) hit:
> registry validation failed for package 1 (public/playwright/mcp): OCI packages must not have 'registryBaseUrl' field - use canonical reference in 'identifier' instead

The schema permits `registryBaseUrl`, but the registry's runtime validator rejects it for OCI. The npm entry validated cleanly.

## Fix
Drop the OCI package entry from `server.json`. The npm listing alone resolves #1477 (VS Code + Copilot in `registryOnly` mode installs via npx). Docker users still pull directly from `playwright.azurecr.io` — that channel doesn't need the registry to be discoverable.

## Why not reformat the OCI identifier
The canonical-reference form (`registry/repo:tag`) bakes the version into the string, which means each release has to bump both `version` and the tag inside `identifier`. The version-validation step in CI would also need OCI-specific logic. Manageable but extra plumbing for a channel we don't need to list. Can be added back in a focused PR if it's ever needed.

## Verifying
After merge, manually fire the `Publish` workflow against `main` from the Actions tab to publish v0.0.72 retroactively.