### PR TITLE
chore(ci): bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 24
+    - name: Use Node.js 22
       uses: actions/setup-node@v5
       with:
-        node-version: '24'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
@@ -29,10 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 24
+    - name: Use Node.js 22
       uses: actions/setup-node@v5
       with:
-        node-version: '24'
+        node-version: '22'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 24
+    - name: Use Node.js 22
       uses: actions/setup-node@v5
       with:
-        node-version: '24'
+        node-version: '22'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 24
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
@@ -29,10 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 24
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 24
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - name: Use Node.js 22
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
@@ -28,11 +28,11 @@ jobs:
         os: [ubuntu-latest, macos-15, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - name: Use Node.js 22
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
@@ -46,20 +46,20 @@ jobs:
   test_mcp_docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - name: Use Node.js 22
+      uses: actions/setup-node@v5
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Playwright install
       run: npx playwright install --with-deps chromium
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         tags: playwright-mcp-dev:latest
         cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 20
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '20'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
@@ -29,10 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 20
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '20'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Use Node.js 22
+    - name: Use Node.js 20
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '20'
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
       - name: Update npm
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
       - name: Update npm
@@ -124,11 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up QEMU # Needed for multi-platform builds (e.g., arm64 on amd64 runner)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx # Needed for multi-platform builds
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Azure Login via OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_DOCKER_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_DOCKER_TENANT_ID }}
@@ -137,7 +137,7 @@ jobs:
         run: az acr login --name playwright
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
@@ -145,7 +145,7 @@ jobs:
           tags: |
             playwright.azurecr.io/public/playwright/mcp:${{ github.event.release.tag_name }}
             playwright.azurecr.io/public/playwright/mcp:latest
-      - uses: oras-project/setup-oras@v1
+      - uses: oras-project/setup-oras@v2
       - name: Set oras tags
         run: |
           attach_eol_manifest() {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Get current date
         id: date
@@ -56,11 +53,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
-      - name: Update npm
-        run: npm install -g npm@latest
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run lint


### PR DESCRIPTION
## Summary
- Bump JavaScript actions to majors that ship `using: node24`, so the runtime moves off Node 20.
- Bump CI `node-version` from 20 to 22 (Node 20 reached end-of-life in April 2026).
- GitHub is forcing JavaScript actions to Node 24 by default on 2026-06-02 and removing Node 20 from runners on 2026-09-16.

Action bumps:
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `docker/setup-qemu-action@v3` → `@v4`
- `docker/setup-buildx-action@v3` → `@v4`
- `docker/build-push-action@v6` → `@v7`
- `azure/login@v2` → `@v3`
- `oras-project/setup-oras@v1` → `@v2`

