### PR TITLE
Fix docker entry point in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ docker run -d -i --rm --init --pull=always \
   --name playwright \
   -p 8931:8931 \
   mcr.microsoft.com/playwright/mcp \
-  cli.js --headless --browser chromium --no-sandbox --port 8931 --host 0.0.0.0
+  /app/cli.js --headless --browser chromium --no-sandbox --port 8931 --host 0.0.0.0
 ```
 
 The server will listen on host port **8931** and can be reached by any MCP client.  


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the correct path for running the Playwright MCP server in Docker. The change ensures that the documentation matches the actual location of the `cli.js` file inside the container.

- Documentation update:
  * Changed the Docker command example to use `/app/cli.js` instead of `cli.js`, specifying the correct path to the entrypoint script within the container.

Fixes #1609