### PR TITLE
docs: explain --cdp-endpoint with a manually launched real Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,50 @@ state [here](https://playwright.dev/docs/auth).
 
 The Playwright MCP Chrome Extension allows you to connect to existing browser tabs and leverage your logged-in sessions and browser state. See [microsoft/playwright › packages/extension](https://github.com/microsoft/playwright/tree/main/packages/extension#readme) for installation and setup instructions.
 
+**Connect to your own Chrome via CDP**
+
+If you'd rather not install an extension and want Playwright MCP to drive a real Chrome that you launched yourself — with your cookies, extensions, and any extra flags — start a dedicated Chrome instance with the remote debugging port enabled and then point MCP at it via [`--cdp-endpoint`](#configuration).
+
+Launch Chrome with a **dedicated user-data-dir** (Chrome refuses CDP attach on your default profile for security, so a separate profile dir is required):
+
+```bash
+# macOS
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.playwright-mcp-chrome"
+
+# Linux
+google-chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.playwright-mcp-chrome"
+
+# Windows (PowerShell)
+& "C:\Program Files\Google\Chrome\Application\chrome.exe" `
+  --remote-debugging-port=9222 `
+  --user-data-dir="$env:USERPROFILE\.playwright-mcp-chrome"
+```
+
+Log in once in that window; the cookies are written to the `--user-data-dir` and persist across launches. Then configure Playwright MCP to attach over CDP instead of launching its own browser:
+
+```js
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--cdp-endpoint=http://localhost:9222"
+      ]
+    }
+  }
+}
+```
+
+This is useful when you want the AI assistant to drive the *same* browser you have open — for example, to inspect requests made by an SaaS you're already authenticated into without re-logging-in inside the MCP-managed profile.
+
+> [!IMPORTANT]
+> The `--user-data-dir` you pass to Chrome must **not** be your default profile (`~/Library/Application Support/Google/Chrome/Default` on macOS, etc.). Chrome blocks CDP attach on the default profile for security; you must use a dedicated directory.
+
 ### Initial state
 
 There are multiple ways to provide the initial state to the browser context or a page.


### PR DESCRIPTION
## Summary

The **User profile** section in the README covers three paths to a persistent browser session:
- Persistent profile (Playwright's bundled Chromium with `--user-data-dir`)
- Isolated mode
- The Chrome browser extension

`--cdp-endpoint` is documented in the configuration flag table but there is no narrative coverage of using it against a real Chrome the user launched themselves. This is a frequently-asked workflow — users want MCP to drive the same Chrome they already have logged in to (a SaaS, a staging environment, etc.) without installing an extension or re-logging-in inside Playwright's bundled Chromium.

This PR adds a fourth subsection — **Connect to your own Chrome via CDP** — that walks through:

- The cross-platform launch command (macOS / Linux / Windows PowerShell)
- The MCP config snippet using `--cdp-endpoint=http://localhost:9222`
- The non-obvious gotcha: Chrome refuses CDP attach on the default profile for security reasons, so a dedicated `--user-data-dir` is **mandatory** (highlighted with a callout)

## Motivation

Related discussions and feature requests where this workflow comes up:
- microsoft/playwright-mcp#347 *(how to record traffic, closed)*
- microsoft/playwright-mcp#1130 *(expose CDP port for the browser MCP launches, closed COMPLETED)*

In both cases users land on `--cdp-endpoint` after trial and error. Documenting the recipe should cut the support load and lower the barrier to a real-Chrome workflow.

## Scope

Docs-only. No code, no behavior change. CONTRIBUTING.md exempts minor documentation fixes from the issue-first rule.

## Test plan

- [x] README renders correctly (mermaid-free, plain markdown + code fences)
- [x] All three launch commands verified on a real Chrome 148 install (the recipe is what's actively used in https://github.com/mohamedalwhaidi/playwright-attach-chrome)
- [x] No links broken; the "configuration" anchor target exists in the README