### PR TITLE
Add MCP Observatory CI check

### DIFF
--- a/.github/workflows/mcp-observatory.yml
+++ b/.github/workflows/mcp-observatory.yml
@@ -1,0 +1,19 @@
+name: MCP Observatory
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  mcp-observatory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          target: mcp-observatory.target.json
+          deep: true
+          security: true
+          comment-on-pr: true

--- a/mcp-observatory.target.json
+++ b/mcp-observatory.target.json
@@ -1,0 +1,22 @@
+{
+  "targetId": "mcp-server",
+  "adapter": "local-process",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@playwright/mcp@latest"
+  ],
+  "securitySuppressions": [
+    "browser_close:permissive-schema",
+    "browser_evaluate:shell-injection",
+    "browser_evaluate:broad-filesystem",
+    "browser_navigate_back:permissive-schema",
+    "browser_run_code_unsafe:shell-injection",
+    "browser_run_code_unsafe:broad-filesystem"
+  ],
+  "skipInvoke": true,
+  "timeoutMs": 60000,
+  "metadata": {
+    "observatory": "certification-pr"
+  }
+}


### PR DESCRIPTION
This adds a lightweight MCP Observatory check for the Playwright MCP server.\n\nWhy it helps:\n\n- verifies the MCP tool surface still responds correctly\n- catches schema drift and common security footguns before release\n- posts a readable PR report for maintainers\n- gives users a compatibility signal when evaluating MCP servers\n\nI validated the target locally with:\n\n```bash\nnpx @kryptosai/mcp-observatory@latest test --target mcp-observatory.target.json --security --deep\n```\n\nResult: passed, with 23 tools detected from `npx -y @playwright/mcp@latest`.\n\nThe target config uses `skipInvoke` because several browser tools require page state or user-provided arguments to invoke meaningfully. It also suppresses intentional browser automation surfaces such as `browser_evaluate` and `browser_run_code_unsafe`, while keeping all other compatibility, schema, and security checks active.\n\nIt runs in GitHub Actions and does not require an MCP Observatory account.