### PR TITLE
docs: fix CDP header env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Playwright MCP server supports following arguments. They can be provided in the 
 | --browser <browser> | browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.<br>*env* `PLAYWRIGHT_MCP_BROWSER` |
 | --caps <caps> | comma-separated list of additional capabilities to enable, possible values: vision, pdf, devtools.<br>*env* `PLAYWRIGHT_MCP_CAPS` |
 | --cdp-endpoint <endpoint> | CDP endpoint to connect to.<br>*env* `PLAYWRIGHT_MCP_CDP_ENDPOINT` |
-| --cdp-header <headers...> | CDP headers to send with the connect request, multiple can be specified.<br>*env* `PLAYWRIGHT_MCP_CDP_HEADER` |
+| --cdp-header <headers...> | CDP headers to send with the connect request, multiple can be specified.<br>*env* `PLAYWRIGHT_MCP_CDP_HEADERS` |
 | --cdp-timeout <timeout> | timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms<br>*env* `PLAYWRIGHT_MCP_CDP_TIMEOUT` |
 | --codegen <lang> | specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".<br>*env* `PLAYWRIGHT_MCP_CODEGEN` |
 | --config <path> | path to the configuration file.<br>*env* `PLAYWRIGHT_MCP_CONFIG` |

--- a/update-readme.js
+++ b/update-readme.js
@@ -141,6 +141,18 @@ async function updateTools(content) {
 }
 
 /**
+ * @param {string} prefix
+ * @returns {string}
+ */
+function optionEnvName(prefix) {
+  if (prefix === 'secrets')
+    return 'PLAYWRIGHT_MCP_SECRETS_FILE';
+  if (prefix === 'cdp-header')
+    return 'PLAYWRIGHT_MCP_CDP_HEADERS';
+  return `PLAYWRIGHT_MCP_` + prefix.toUpperCase().replace(/-/g, '_');
+}
+
+/**
  * @param {string} content
  * @returns {Promise<string>}
  */
@@ -177,9 +189,7 @@ async function updateOptions(content) {
   table.push(`|--------|-------------|`);
   for (const option of options) {
     const prefix = option.name.split(' ')[0];
-    const envName = prefix === 'secrets'
-      ? 'PLAYWRIGHT_MCP_SECRETS_FILE'
-      : `PLAYWRIGHT_MCP_` + prefix.toUpperCase().replace(/-/g, '_');
+    const envName = optionEnvName(prefix);
     table.push(`| --${option.name} | ${option.value}<br>*env* \`${envName}\` |`);
   }
 
@@ -189,7 +199,7 @@ async function updateOptions(content) {
     envTable.push(`|-------------|`);
     for (const option of options) {
       const prefix = option.name.split(' ')[0];
-      const envName = `PLAYWRIGHT_MCP_` + prefix.toUpperCase().replace(/-/g, '_');
+      const envName = optionEnvName(prefix);
       envTable.push(`| \`${envName}\` ${option.value} |`);
     }
     console.log(envTable.join('\n'));


### PR DESCRIPTION
## Summary

Fix the generated README docs for `--cdp-header` to use the runtime-supported env var: `PLAYWRIGHT_MCP_CDP_HEADERS`.

Related runtime coverage issue: microsoft/playwright#41451

## Changes

- Update the README options table.
- Update `update-readme.js` so future README generation keeps this env var aligned with the runtime.

## Testing

- `node --check update-readme.js`
- `git diff --check`