### PR TITLE
chore: roll Playwright to 1.62.0-alpha-2026-06-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,7 @@ http.createServer(async (req, res) => {
     - `type` (string): Image format for the screenshot. Default is png.
     - `filename` (string, optional): File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg}` if not specified. Prefer relative file names to stay within the output directory.
     - `fullPage` (boolean, optional): When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.
+    - `scale` (string): Image resolution scale. "css" produces a screenshot sized in CSS pixels (smaller, consistent across devices). "device" produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.
   - Read-only: **true**
 
 <!-- NOTE: This has been generated via update-readme.js -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.76",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0-alpha-1781023400000",
-        "playwright-core": "1.61.0-alpha-1781023400000"
+        "playwright": "1.62.0-alpha-2026-06-29",
+        "playwright-core": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright-mcp": "cli.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
-        "@playwright/test": "1.61.0-alpha-1781023400000",
+        "@playwright/test": "1.62.0-alpha-2026-06-29",
         "@types/node": "^24.3.0"
       },
       "engines": {
@@ -79,13 +79,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-EYeA59CsSOtiQgKTBAyl321SwaWzLYD4wU9GDAt8kFpYCco3sClPZBPdKXdUwlrNqOFAbseUYtiFudxFs/h02w==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-g9foBBuWf7IoALxyck3GJjjl/dsUewmxXz8a3JNgKgqgHFOZou9DZA7isi0hLU9Lz+75LeBSxN92E+aI7KAbUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0-alpha-1781023400000"
+        "playwright": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright": "cli.js"
@@ -938,12 +938,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-ugaMuh6rAOqmbaxrM7+XQSs7M6yPXykq5gVugJPClHcJ4Cqxmky5rDHhrCt4wmaILUeMdI7kPBCx3zMx2Qu+bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0-alpha-1781023400000"
+        "playwright-core": "1.62.0-alpha-2026-06-29"
       },
       "bin": {
         "playwright": "cli.js"
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0-alpha-1781023400000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781023400000.tgz",
-      "integrity": "sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==",
+      "version": "1.62.0-alpha-2026-06-29",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-06-29.tgz",
+      "integrity": "sha512-/13EvW8l9Bmvt9nKHey+OcvZ8nob2FM8BCKBsUNwbXgmT4Hc0XX2b6mOErU0RBYNedOCa9q15USI7SY9K17v4w==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     }
   },
   "dependencies": {
-    "playwright": "1.61.0-alpha-1781023400000",
-    "playwright-core": "1.61.0-alpha-1781023400000"
+    "playwright": "1.62.0-alpha-2026-06-29",
+    "playwright-core": "1.62.0-alpha-2026-06-29"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "@playwright/test": "1.61.0-alpha-1781023400000",
+    "@playwright/test": "1.62.0-alpha-2026-06-29",
     "@types/node": "^24.3.0"
   },
   "bin": {


### PR DESCRIPTION
## What's New

### Tool Improvements

- **`browser_take_screenshot` — `scale` option** — Choose between CSS-pixel screenshots (smaller, device-consistent) and device-pixel screenshots (high resolution) ([#41465](https://github.com/microsoft/playwright/pull/41465))
- **Configurable heartbeat timeout** — The heartbeat ping timeout is now configurable ([#41391](https://github.com/microsoft/playwright/pull/41391))

### Dashboard

- Route the `--port` dashboard through the singleton ([#41466](https://github.com/microsoft/playwright/pull/41466))

## Bug Fixes

- Redact secrets in console log artifacts ([#41515](https://github.com/microsoft/playwright/pull/41515))
- Never include `data:` URL payloads in snapshot or network output ([#41450](https://github.com/microsoft/playwright/pull/41450))
- List a failed network request only once ([#41481](https://github.com/microsoft/playwright/pull/41481))
- Wait for the next pause or context closure in `browser_resume` ([#41293](https://github.com/microsoft/playwright/pull/41293))
- Pass the action timeout to `browser_wait_for` waitFor calls ([#41270](https://github.com/microsoft/playwright/pull/41270))
- Check the tracing state before stopping in `browser_stop_tracing` ([#41040](https://github.com/microsoft/playwright/pull/41040))
- Assign caps as an array for the legacy `--vision` flag ([#41253](https://github.com/microsoft/playwright/pull/41253))
- Use optional chaining for the nullable browser on disposal ([#41237](https://github.com/microsoft/playwright/pull/41237))
- Add a missing `.catch()` on the sessionLog write queue ([#41234](https://github.com/microsoft/playwright/pull/41234))
