### PR TITLE
chore: mark v0.0.77

### DIFF
--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -58,12 +58,6 @@ Filter for `feat(mcp)`, `fix(mcp)`, `feat(extension)`, `fix(extension)`, and das
 
 Follow the format from the prior release: `## What's New` (with `### New Tools`, `### Tool Improvements`, optional `### Browser Extension`, `### Dashboard`, `### Other Changes`) and `## Bug Fixes`. Link each entry to its PR (`[#NNNNN](https://github.com/microsoft/playwright/pull/NNNNN)` or the playwright-mcp equivalent). **Do not mention features that are not yet enabled by default** — confirm with the user before listing experimental flags.
 
-## 6. Create the draft release
+## 6. Upload release PR
 
-```bash
-gh release create v0.0.<next> --repo microsoft/playwright-mcp \
-  --draft --title "v0.0.<next>" --target main \
-  --notes-file release-notes.md
-```
-
-Publish the draft once the mark PR is merged.
+Upload the release PR with the release-notes as description.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright/mcp",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright/mcp",
-      "version": "0.0.76",
+      "version": "0.0.77",
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.0-alpha-2026-06-29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/mcp",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "Playwright Tools for MCP",
   "repository": {
     "type": "git",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/microsoft/playwright-mcp",
     "source": "github"
   },
-  "version": "0.0.76",
+  "version": "0.0.77",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@playwright/mcp",
-      "version": "0.0.76",
+      "version": "0.0.77",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What's New

### Tool Improvements

- **`browser_take_screenshot` — `scale` option** — Choose between CSS-pixel screenshots (smaller, device-consistent) and device-pixel screenshots (high resolution) ([#41465](https://github.com/microsoft/playwright/pull/41465))
- **Configurable heartbeat timeout** — The heartbeat ping timeout is now configurable ([#41391](https://github.com/microsoft/playwright/pull/41391))

## Bug Fixes

- Redact secrets in console log artifacts ([#41515](https://github.com/microsoft/playwright/pull/41515))
- Never include `data:` URL payloads in snapshot or network output ([#41450](https://github.com/microsoft/playwright/pull/41450))
- List a failed network request only once ([#41481](https://github.com/microsoft/playwright/pull/41481))
- Wait for the next pause or context closure in `browser_resume` ([#41293](https://github.com/microsoft/playwright/pull/41293))
- Pass the action timeout to `browser_wait_for` waitFor calls ([#41270](https://github.com/microsoft/playwright/pull/41270))
- Check the tracing state before stopping in `browser_stop_tracing` ([#41040](https://github.com/microsoft/playwright/pull/41040))
- Assign caps as an array for the legacy `--vision` flag ([#41253](https://github.com/microsoft/playwright/pull/41253))
- Use optional chaining for the nullable browser on disposal ([#41237](https://github.com/microsoft/playwright/pull/41237))
- Add a missing `.catch()` on the sessionLog write queue ([#41234](https://github.com/microsoft/playwright/pull/41234))
