### PR TITLE
fix: readme typo, update devcontainer playwright version, remove shebang from .d.ts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
   "name": "Playwright",
-  "image": "mcr.microsoft.com/playwright:v1.58.2-noble",
+  "image": "mcr.microsoft.com/playwright:v1.61.0-noble",
   "privileged": true,
   "init": true,
   "remoteUser": "pwuser",

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add via the Amp VS Code extension settings screen or by updating your settings.j
 
 **Amp CLI Setup:**
 
-Add via the `amp mcp add`command below
+Add via the `amp mcp add` command below
 
 ```bash
 amp mcp add playwright -- npx @playwright/mcp@latest

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Copyright (c) Microsoft Corporation.
  *


### PR DESCRIPTION
Hey, couple of small things I spotted:

- there was a missing space in the README where it says `amp mcp add`command — just needed a space before "command"
- the devcontainer image was pinned to Playwright v1.58.2 but the package.json uses a much newer version, so codespace users would get mismatched browser binaries. bumped it to v1.61.0
- index.d.ts had a `#!/usr/bin/env node` shebang at the top, which doesn't make sense for a type declaration file since it's never executed directly