### PR TITLE
chore: roll Playwright to 1.62.0-alpha-2026-07-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Playwright MCP server supports following arguments. They can be provided in the 
 | --config <path> | path to the configuration file.<br>*env* `PLAYWRIGHT_MCP_CONFIG` |
 | --console-level <level> | level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.<br>*env* `PLAYWRIGHT_MCP_CONSOLE_LEVEL` |
 | --device <device> | device to emulate, for example: "iPhone 15"<br>*env* `PLAYWRIGHT_MCP_DEVICE` |
+| --mobile | emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit). Mobile pages are usually lighter, which saves tokens. Cannot be combined with --device.<br>*env* `PLAYWRIGHT_MCP_MOBILE` |
 | --executable-path <path> | path to the browser executable.<br>*env* `PLAYWRIGHT_MCP_EXECUTABLE_PATH` |
 | --extension | Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright Extension" to be installed.<br>*env* `PLAYWRIGHT_MCP_EXTENSION` |
 | --endpoint <endpoint> | Bound browser endpoint to connect to.<br>*env* `PLAYWRIGHT_MCP_ENDPOINT` |
@@ -915,6 +916,16 @@ http.createServer(async (req, res) => {
   - Parameters:
     - `fields` (array): Fields to fill in
   - Read-only: **false**
+
+<!-- NOTE: This has been generated via update-readme.js -->
+
+- **browser_find**
+  - Title: Find in page snapshot
+  - Description: Search the accessibility snapshot of the current page for text or a regular expression. Returns matching snapshot nodes with a few lines of surrounding context (like search snippets), each shown under its path from the root of the tree, which is cheaper than capturing the whole snapshot when you only need to locate an element and its ref.
+  - Parameters:
+    - `text` (string, optional): Plain text to search for in the page snapshot (case-insensitive substring match). Provide either text or regex, not both.
+    - `regex` (string, optional): Regular expression to search for in the page snapshot. Matching is case-sensitive by default; wrap the pattern in slashes to add flags, e.g. "/error/i" for case-insensitive. Provide either text or regex, not both.
+  - Read-only: **true**
 
 <!-- NOTE: This has been generated via update-readme.js -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.77",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-2026-06-29",
-        "playwright-core": "1.62.0-alpha-2026-06-29"
+        "playwright": "1.62.0-alpha-2026-07-08",
+        "playwright-core": "1.62.0-alpha-2026-07-08"
       },
       "bin": {
         "playwright-mcp": "cli.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
-        "@playwright/test": "1.62.0-alpha-2026-06-29",
+        "@playwright/test": "1.62.0-alpha-2026-07-08",
         "@types/node": "^24.3.0"
       },
       "engines": {
@@ -79,19 +79,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0-alpha-2026-06-29",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-06-29.tgz",
-      "integrity": "sha512-g9foBBuWf7IoALxyck3GJjjl/dsUewmxXz8a3JNgKgqgHFOZou9DZA7isi0hLU9Lz+75LeBSxN92E+aI7KAbUQ==",
+      "version": "1.62.0-alpha-2026-07-08",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-07-08.tgz",
+      "integrity": "sha512-D0qozGfVOuI8x9fD70vK0H5ntL+rNz5oOHRhT+SxMJIKP0OyjA6P95GfLFUeliaCxR1nR3jc4KRZcI2UhRYyXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-2026-06-29"
+        "playwright": "1.62.0-alpha-2026-07-08"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
@@ -938,33 +938,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0-alpha-2026-06-29",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-06-29.tgz",
-      "integrity": "sha512-ugaMuh6rAOqmbaxrM7+XQSs7M6yPXykq5gVugJPClHcJ4Cqxmky5rDHhrCt4wmaILUeMdI7kPBCx3zMx2Qu+bg==",
+      "version": "1.62.0-alpha-2026-07-08",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-07-08.tgz",
+      "integrity": "sha512-5vivHdZSnbUW3iutwp2kbr9wjsdFR7OIEUcMvsR5g8Iy/PeYm0uZRwKwTsnZMPr43uFCdW4RQIj0ioszIL31MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0-alpha-2026-06-29"
+        "playwright-core": "1.62.0-alpha-2026-07-08"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0-alpha-2026-06-29",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-06-29.tgz",
-      "integrity": "sha512-/13EvW8l9Bmvt9nKHey+OcvZ8nob2FM8BCKBsUNwbXgmT4Hc0XX2b6mOErU0RBYNedOCa9q15USI7SY9K17v4w==",
+      "version": "1.62.0-alpha-2026-07-08",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-07-08.tgz",
+      "integrity": "sha512-1GEx9eELpB6cdtb1MTSeh7K4LP5k9vuaT4HlIsldD/8nvVhf1k2DqBQZHHyAs3oSTfz6MhqVaMEM4VkyjoPsLw==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     }
   },
   "dependencies": {
-    "playwright": "1.62.0-alpha-2026-06-29",
-    "playwright-core": "1.62.0-alpha-2026-06-29"
+    "playwright": "1.62.0-alpha-2026-07-08",
+    "playwright-core": "1.62.0-alpha-2026-07-08"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "@playwright/test": "1.62.0-alpha-2026-06-29",
+    "@playwright/test": "1.62.0-alpha-2026-07-08",
     "@types/node": "^24.3.0"
   },
   "bin": {

--- a/tests/capabilities.spec.ts
+++ b/tests/capabilities.spec.ts
@@ -26,6 +26,7 @@ test('test snapshot tool list', async ({ client }) => {
     'browser_evaluate',
     'browser_file_upload',
     'browser_fill_form',
+    'browser_find',
     'browser_handle_dialog',
     'browser_hover',
     'browser_select_option',


### PR DESCRIPTION
## Summary
- Roll playwright, playwright-core and @playwright/test to 1.62.0-alpha-2026-07-08
- Add new browser_find tool to the expected tool list and regenerated README

🤖 Generated with [Claude Code](https://claude.com/claude-code)