### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-microsoft-playwright-mcp)](https://mcpindex.ai/server/io-github-microsoft-playwright-mcp)
+
 ## Playwright MCP
 
 A Model Context Protocol (MCP) server that provides browser automation capabilities using [Playwright](https://playwright.dev). This server enables LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models.


### PR DESCRIPTION
Hey, ran playwright-mcp through mcpindex's screening (description-level check for injection/manipulation patterns in the tool description). Came back clean, so added the badge to your README. It's advisory, not a security certification. Close this if it's not useful to you. Heads up that this repo requires the Microsoft CLA, which I'll leave to Gautam to complete personally rather than assume on his behalf.