### PR TITLE
devops: add ESRP pipeline for publishing npm alpha versions

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -72,13 +72,13 @@ extends:
           displayName: "npm run build"
 
         - task: Bash@3
-          displayName: "Set alpha version with commit timestamp"
+          displayName: "Set alpha version with current timestamp"
           inputs:
             targetType: "inline"
             script: |
               set -e
               BASE_VERSION=$(node -p "require('./package.json').version.split('-')[0]")
-              TIMESTAMP=$(git show -s --format=%ct HEAD)
+              TIMESTAMP=$(date +%s)
               npm version "${BASE_VERSION}-alpha-${TIMESTAMP}000" --no-git-tag-version
 
         - task: Bash@3

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,4 +1,4 @@
-# Publishes @next (alpha) version of @playwright/mcp via ESRP. Manual trigger only.
+# Publishes @test (alpha) version of @playwright/mcp via ESRP. Manual trigger only.
 trigger: none
 
 pr: none
@@ -113,7 +113,7 @@ extends:
               intent: 'PackageDistribution'
               contenttype: 'npm'
               # npm dist-tag to publish with.
-              productstate: 'next'
+              productstate: 'test'
               folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
               waitforreleasecompletion: true
               owners: 'yurys@microsoft.com'

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,0 +1,124 @@
+# Publishes @next (alpha) version of @playwright/mcp via ESRP. Manual trigger only.
+trigger: none
+
+pr: none
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: DevDivPlaywrightAzurePipelinesUbuntu2204
+      os: linux
+    sdl:
+      sourceAnalysisPool:
+        # SDL tools require windows, see https://aka.ms/AAo6v8e
+        name: DevDivPlaywrightAzurePipelinesWindows2022
+        os: windows
+    stages:
+    - stage: Stage
+      jobs:
+      - job: Build
+        displayName: "Build npm package"
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            path: $(Build.ArtifactStagingDirectory)/esrp-build
+            artifact: esrp-build
+        steps:
+        - checkout: self
+          displayName: "Checkout code"
+
+        - task: Bash@3
+          displayName: "Check the branch is main"
+          inputs:
+            targetType: "inline"
+            script: |
+              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" ]]; then
+                echo "Alpha versions can only be published from main."
+                echo "Unexpected branch: $BUILD_SOURCE_BRANCH"
+                exit 1
+              fi
+          env:
+            BUILD_SOURCE_BRANCH: $(Build.SourceBranch)
+
+        - task: UseNode@1
+          inputs:
+            version: '24.x'
+          displayName: "Install Node.js"
+
+        - task: Bash@3
+          displayName: "setup .npmrc"
+          inputs:
+            targetType: "inline"
+            script: |
+              echo "registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/DevDiv_PublicPackages/npm/registry/" >> .npmrc
+
+        - task: npmAuthenticate@0
+          displayName: "authenticate the private npm registry"
+          inputs:
+            workingFile: .npmrc
+
+        - script: npm ci
+          displayName: "npm ci"
+
+        - script: npm run build
+          displayName: "npm run build"
+
+        - task: Bash@3
+          displayName: "Set alpha version with commit timestamp"
+          inputs:
+            targetType: "inline"
+            script: |
+              set -e
+              BASE_VERSION=$(node -p "require('./package.json').version.split('-')[0]")
+              TIMESTAMP=$(git show -s --format=%ct HEAD)
+              npm version "${BASE_VERSION}-alpha-${TIMESTAMP}000" --no-git-tag-version
+
+        - task: Bash@3
+          displayName: "Pack the package"
+          inputs:
+            targetType: "inline"
+            script: |
+              set -e
+              mkdir -p "$(Build.ArtifactStagingDirectory)/esrp-build"
+              npm pack --pack-destination="$(Build.ArtifactStagingDirectory)/esrp-build"
+              ls -la "$(Build.ArtifactStagingDirectory)/esrp-build"
+
+      - job: Publish
+        displayName: "ESRP Release to npm"
+        dependsOn: Build
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            artifactName: esrp-build
+            targetPath: $(Build.ArtifactStagingDirectory)/esrp-build
+        steps:
+          - checkout: none
+          - task: EsrpRelease@11
+            inputs:
+              connectedservicename: 'Playwright-ESRP-PME'
+              usemanagedidentity: true
+              keyvaultname: 'playwright-esrp-pme'
+              signcertname: 'ESRP-Release-Sign'
+              clientid: '13434a40-7de4-4c23-81a3-d843dc81c2c5'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              # npm dist-tag to publish with.
+              productstate: 'next'
+              folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
+              waitforreleasecompletion: true
+              owners: 'yurys@microsoft.com'
+              approvers: 'yurys@microsoft.com'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'Playwright'
+              domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+            displayName: 'ESRP Release to npm'


### PR DESCRIPTION
## Summary
- Add `.azure-pipelines/publish.yml` that packs `@playwright/mcp` with an `-alpha-<current timestamp>` version and releases it to npm via `EsrpRelease@11`.
- Publishes under the `test` dist-tag for now; will switch to `next` after the pipeline is validated.
- Same setup as the microsoft/playwright ESRP pipeline; manual trigger only, guarded to `main`.