### PR TITLE
Add context-cost badge (4,024 tokens across 24 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Playwright MCP
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fplaywright.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 A Model Context Protocol (MCP) server that provides browser automation capabilities using [Playwright](https://playwright.dev). This server enables LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models.
 
 ### Playwright MCP vs Playwright CLI


### PR DESCRIPTION
One line: a shields.io badge showing what @playwright/mcp's tool schemas cost in context tokens — currently **4,024 tokens across 24 tools** (largest: `browser_take_screenshot` at 329), measured 2026-08-16. Notable in our 57-server sweep: this is the most-installed MCP server we measured (~4.8M npm downloads/week) and still lands close to the 2,636 median — an average of ~168 tokens per tool, which is disciplined schema design worth surfacing.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/playwright/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/playwright/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).