### PR TITLE
devops: publish all npm versions via ESRP pipeline

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,7 +1,21 @@
-# Publishes @test (alpha) version of @playwright/mcp via ESRP. Manual trigger only.
-trigger: none
+# Publishes @playwright/mcp via ESRP:
+# - @next (alpha with today's date) from main, daily on schedule
+# - @next (alpha with current timestamp) from main, on manual trigger
+# - @latest from v* release tags (pushed when a GitHub release is published)
+trigger:
+  tags:
+    include:
+    - v*
 
 pr: none
+
+schedules:
+- cron: '0 8 * * *'
+  displayName: "Daily @next publish"
+  branches:
+    include:
+    - main
+  always: true
 
 resources:
   repositories:
@@ -36,12 +50,12 @@ extends:
           displayName: "Checkout code"
 
         - task: Bash@3
-          displayName: "Check the branch is main"
+          displayName: "Check the branch is main or a v* tag"
           inputs:
             targetType: "inline"
             script: |
-              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" ]]; then
-                echo "Alpha versions can only be published from main."
+              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" && "$BUILD_SOURCE_BRANCH" != refs/tags/v* ]]; then
+                echo "Can only publish from main or v* tags."
                 echo "Unexpected branch: $BUILD_SOURCE_BRANCH"
                 exit 1
               fi
@@ -72,14 +86,32 @@ extends:
           displayName: "npm run build"
 
         - task: Bash@3
-          displayName: "Set alpha version with current timestamp"
+          name: setVersion
+          displayName: "Set version and dist-tag"
           inputs:
             targetType: "inline"
             script: |
               set -e
               BASE_VERSION=$(node -p "require('./package.json').version.split('-')[0]")
-              TIMESTAMP=$(date +%s)
-              npm version "${BASE_VERSION}-alpha-${TIMESTAMP}000" --no-git-tag-version
+              if [[ "$BUILD_SOURCE_BRANCH" == refs/tags/v* ]]; then
+                # Release version is already checked in, only publish what the tag points at.
+                NPM_DIST_TAG="latest"
+                if [[ "$BUILD_SOURCE_BRANCH" != "refs/tags/v$BASE_VERSION" ]]; then
+                  echo "ERROR: version '$BASE_VERSION' does not match tag '$BUILD_SOURCE_BRANCH'"
+                  exit 1
+                fi
+              elif [[ "$BUILD_REASON" == "Schedule" ]]; then
+                NPM_DIST_TAG="next"
+                npm version "${BASE_VERSION}-alpha-$(date -u +%Y-%m-%d)" --no-git-tag-version
+              else
+                NPM_DIST_TAG="next"
+                npm version "${BASE_VERSION}-alpha-$(date +%s)000" --no-git-tag-version
+              fi
+              echo "Publishing version $(node -p "require('./package.json').version") with dist-tag $NPM_DIST_TAG"
+              echo "##vso[task.setvariable variable=npmDistTag;isOutput=true]$NPM_DIST_TAG"
+          env:
+            BUILD_SOURCE_BRANCH: $(Build.SourceBranch)
+            BUILD_REASON: $(Build.Reason)
 
         - task: Bash@3
           displayName: "Pack the package"
@@ -94,6 +126,8 @@ extends:
       - job: Publish
         displayName: "ESRP Release to npm"
         dependsOn: Build
+        variables:
+          npmDistTag: $[ dependencies.Build.outputs['setVersion.npmDistTag'] ]
         templateContext:
           type: releaseJob
           isProduction: true
@@ -113,7 +147,7 @@ extends:
               intent: 'PackageDistribution'
               contenttype: 'npm'
               # npm dist-tag to publish with.
-              productstate: 'test'
+              productstate: '$(npmDistTag)'
               folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
               waitforreleasecompletion: true
               owners: 'yurys@microsoft.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,76 +1,15 @@
+# npm publishing (@next and @latest) is done by the ESRP pipeline,
+# see .azure-pipelines/publish.yml
 name: Publish
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 8 * * *'
   release:
     types: [published]
 
 jobs:
-  publish-mcp-canary-npm:
-    if: github.event.schedule || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write  # Required for OIDC npm publishing
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org/
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Get current version
-        id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Set canary version
-        id: canary-version
-        run: echo "version=${{ steps.version.outputs.version }}-alpha-${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
-
-      - name: Update package.json version
-        run: npm version ${{ steps.canary-version.outputs.version }} --no-git-tag-version
-
-      - run: npm ci
-      - run: npx playwright install --with-deps
-      - run: npm run lint
-      - run: npm run ctest
-
-      - name: Publish to npm with next tag
-        run: npm publish --tag next
-
-  publish-mcp-release-npm:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write  # Required for OIDC npm publishing
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npx playwright install --with-deps
-      - run: npm run lint
-      - run: npm run ctest
-      - run: npm publish
-
   publish-mcp-release-registry:
-    # Runs on release (after npm publish succeeds) or via manual workflow_dispatch
-    # (e.g. to retroactively publish a version, in which case publish-mcp-release-npm
-    # is skipped — the always() + result check lets this job still run).
-    if: |
-      always() &&
-      (github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
-      needs.publish-mcp-release-npm.result != 'failure' &&
-      needs.publish-mcp-release-npm.result != 'cancelled'
-    needs: publish-mcp-release-npm
+    # Runs on release or via manual workflow_dispatch (e.g. to retroactively
+    # publish a version).
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The ESRP pipeline now publishes daily @next (today's date) on schedule, @next with current timestamp on manual runs, and @latest from v* release tags.
- GitHub Actions workflow keeps only the MCP registry and Docker publishing; the registry job no longer depends on the removed npm job.