### PR TITLE
devops: drop scheduled @next publishing

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,5 +1,4 @@
 # Publishes @playwright/mcp via ESRP:
-# - @next (alpha with today's date) from main, daily on schedule
 # - @next (alpha with current timestamp) from main, on manual trigger
 # - @latest from v* release tags (pushed when a GitHub release is published)
 trigger:
@@ -8,14 +7,6 @@ trigger:
     - v*
 
 pr: none
-
-schedules:
-- cron: '0 8 * * *'
-  displayName: "Daily @next publish"
-  branches:
-    include:
-    - main
-  always: true
 
 resources:
   repositories:
@@ -100,9 +91,6 @@ extends:
                   echo "ERROR: version '$BASE_VERSION' does not match tag '$BUILD_SOURCE_BRANCH'"
                   exit 1
                 fi
-              elif [[ "$BUILD_REASON" == "Schedule" ]]; then
-                NPM_DIST_TAG="next"
-                npm version "${BASE_VERSION}-alpha-$(date -u +%Y-%m-%d)" --no-git-tag-version
               else
                 NPM_DIST_TAG="next"
                 npm version "${BASE_VERSION}-alpha-$(date +%s)000" --no-git-tag-version
@@ -111,7 +99,6 @@ extends:
               echo "##vso[task.setvariable variable=npmDistTag;isOutput=true]$NPM_DIST_TAG"
           env:
             BUILD_SOURCE_BRANCH: $(Build.SourceBranch)
-            BUILD_REASON: $(Build.Reason)
 
         - task: Bash@3
           displayName: "Pack the package"


### PR DESCRIPTION
## Summary
- Remove the daily cron from the ESRP pipeline; @next alphas are published on demand (manual trigger), @latest from v* release tags as before.