### PR TITLE
devops: restore npm publishing from GitHub Actions

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,10 +1,9 @@
-# Publishes @playwright/mcp via ESRP:
-# - @next (alpha with current timestamp) from main, on manual trigger
-# - @latest from v* release tags (pushed when a GitHub release is published)
-trigger:
-  tags:
-    include:
-    - v*
+# Publishes @playwright/mcp via ESRP. Manual trigger only, regular publishing
+# is done from GitHub Actions, see .github/workflows/publish.yml.
+# Depending on the selected ref, a manual run publishes:
+# - @next (alpha with current timestamp) from main
+# - @latest from v* release tags
+trigger: none
 
 pr: none
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC npm publishing
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -48,8 +48,8 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC npm publishing
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -74,7 +74,7 @@ jobs:
       contents: read
       id-token: write  # Required for GitHub OIDC auth to the MCP Registry
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate server.json version matches package.json
         run: |
@@ -114,7 +114,7 @@ jobs:
       id-token: write # Needed for OIDC login to Azure
     environment: allow-publishing-docker-to-acr
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU # Needed for multi-platform builds (e.g., arm64 on amd64 runner)
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx # Needed for multi-platform builds

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,82 @@
-# npm publishing (@next and @latest) is done by the ESRP pipeline,
-# see .azure-pipelines/publish.yml
 name: Publish
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *'
   release:
     types: [published]
 
 jobs:
+  publish-mcp-canary-npm:
+    if: github.event.schedule || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC npm publishing
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Get current version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Set canary version
+        id: canary-version
+        run: echo "version=${{ steps.version.outputs.version }}-alpha-${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        run: npm version ${{ steps.canary-version.outputs.version }} --no-git-tag-version
+
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run lint
+      - run: npm run ctest
+
+      - name: Publish to npm with next tag
+        run: npm publish --tag next
+
+  publish-mcp-release-npm:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC npm publishing
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run lint
+      - run: npm run ctest
+      - run: npm publish
+
   publish-mcp-release-registry:
-    # Runs on release or via manual workflow_dispatch (e.g. to retroactively
-    # publish a version).
+    # Runs on release (after npm publish succeeds) or via manual workflow_dispatch
+    # (e.g. to retroactively publish a version, in which case publish-mcp-release-npm
+    # is skipped — the always() + result check lets this job still run).
+    if: |
+      always() &&
+      (github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
+      needs.publish-mcp-release-npm.result != 'failure' &&
+      needs.publish-mcp-release-npm.result != 'cancelled'
+    needs: publish-mcp-release-npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write  # Required for GitHub OIDC auth to the MCP Registry
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Validate server.json version matches package.json
         run: |
@@ -55,7 +116,7 @@ jobs:
       id-token: write # Needed for OIDC login to Azure
     environment: allow-publishing-docker-to-acr
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Set up QEMU # Needed for multi-platform builds (e.g., arm64 on amd64 runner)
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx # Needed for multi-platform builds

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,12 @@
 name: Publish
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 8 * * *'
   release:
     types: [published]
 
 jobs:
   publish-mcp-canary-npm:
-    if: github.event.schedule || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Regular publishing (@next canary and @latest release) goes back to the GitHub Actions workflow with OIDC trusted publishing and provenance.
- The ESRP pipeline stays available for manual on-demand runs only (no automatic triggers).