### PR TITLE
feat: add Agent Plugins 1.0 package

### DIFF
--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -16,7 +16,8 @@ Follow the "Rolling Playwright" steps in `CLAUDE.md`: run `node roll.js`, branch
 ```bash
 git checkout main && git pull
 git checkout -b mark-v0.0.<next>
-# Bump "version" in package.json, package-lock.json (both occurrences), and server.json (both occurrences)
+# Bump "version" in package.json, package-lock.json (both occurrences), server.json (both occurrences),
+# plugin.json, and the @playwright/mcp version pinned in mcp.json
 ```
 
 Do NOT open the PR yet — its body must be the release notes, so write those first (steps 3–5).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,11 +76,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Validate server.json version matches package.json
+      - name: Validate server.json, plugin.json and mcp.json versions match package.json
         run: |
           node -e "
             const pkg = require('./package.json');
             const server = require('./server.json');
+            const plugin = require('./plugin.json');
+            const mcp = require('./mcp.json');
             const mismatches = [];
             if (server.version !== pkg.version)
               mismatches.push(\`server.version=\${server.version} != package.version=\${pkg.version}\`);
@@ -88,8 +90,13 @@ jobs:
               if (p.version !== pkg.version)
                 mismatches.push(\`packages[\${p.identifier}].version=\${p.version} != package.version=\${pkg.version}\`);
             }
+            if (plugin.version !== pkg.version)
+              mismatches.push(\`plugin.version=\${plugin.version} != package.version=\${pkg.version}\`);
+            const args = mcp.mcpServers.playwright.args;
+            if (!args.includes(\`@playwright/mcp@\${pkg.version}\`))
+              mismatches.push(\`mcp.json args=\${JSON.stringify(args)} do not pin @playwright/mcp@\${pkg.version}\`);
             if (mismatches.length) {
-              console.error('server.json is out of sync with package.json:');
+              console.error('server.json, plugin.json or mcp.json is out of sync with package.json:');
               for (const m of mismatches) console.error('  ' + m);
               process.exit(1);
             }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@0.0.80"
+      ]
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "playwright-mcp",
+  "version": "0.0.80",
+  "description": "Browser automation for agents through the Playwright MCP server: navigate, interact with pages via accessibility snapshots, take screenshots and inspect network and console output.",
+  "author": {
+    "name": "Microsoft Corporation"
+  },
+  "homepage": "https://github.com/microsoft/playwright-mcp",
+  "repository": "https://github.com/microsoft/playwright-mcp",
+  "license": "Apache-2.0",
+  "keywords": [
+    "playwright",
+    "browser",
+    "automation",
+    "mcp",
+    "testing"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `plugin.json` and `mcp.json` at the repository root so clients that support [Agent Plugins 1.0](https://agent-plugins.org) (VS Code, Copilot CLI, Cursor, Codex, Kiro) can install the server from the repository URL
- `mcp.json` pins the exact `@playwright/mcp` version; the publish workflow validates it and `plugin.json` against `package.json` alongside the existing `server.json` check

Fixes https://github.com/microsoft/playwright-mcp/issues/1736